### PR TITLE
Ordering for patterns based on 'order' front matter

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,19 +1,26 @@
 module.exports = function (eleventyConfig) {
-    // Set custom directories for input, output, includes, and data
-    eleventyConfig.addPassthroughCopy("src/style.css");
-    eleventyConfig.addPassthroughCopy("src/assets/*");
-    eleventyConfig.setFrontMatterParsingOptions({
-        excerpt: true,
-        // Optional, default is "---"
-        excerpt_separator: "<!-- excerpt -->"
-    });
+  // Set custom directories for input, output, includes, and data
+  eleventyConfig.addPassthroughCopy("src/style.css");
+  eleventyConfig.addPassthroughCopy("src/assets/*");
+  eleventyConfig.setFrontMatterParsingOptions({
+    excerpt: true,
+    // Optional, default is "---"
+    excerpt_separator: "<!-- excerpt -->",
+  });
 
-    return {
-        dir: {
-            input: "src",
-            includes: "_includes",
-            data: "_data",
-            output: "_site"
-        }
-    };
+  // add `order` front matter to each pattern to sort them (lower values firts)
+  eleventyConfig.addCollection("orderedPatterns", function (collectionApi) {
+    return collectionApi.getFilteredByTag("pattern").sort(function (a, b) {
+      return a.data.order - b.data.order;
+    });
+  });
+
+  return {
+    dir: {
+      input: "src",
+      includes: "_includes",
+      data: "_data",
+      output: "_site",
+    },
+  };
 };

--- a/src/index.njk
+++ b/src/index.njk
@@ -11,7 +11,7 @@ id: homepage
 
 <p>Below is the list of common speed design problems and their design solutions. We try not to concentrate on specific technical implementations or specific types of sites so it can be used in any context.</p>
 
-{% for post in collections.pattern %}
+{% for post in collections.orderedPatterns %}
 
     <section class="speed-pattern">
 


### PR DESCRIPTION
Force an order of patterns on homepage by supplying `order` front-matter values in pattern files.