### PR TITLE
Add Convert on Arrival pattern

### DIFF
--- a/src/assets/convert_on_arrival_thumbnail.svg
+++ b/src/assets/convert_on_arrival_thumbnail.svg
@@ -1,29 +1,31 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 300" width="400" height="300">
-  <rect width="400" height="300" fill="#fff4de"/>
-  <text x="200" y="36" text-anchor="middle" font-family="sans-serif" font-size="20" fill="#5a4a2e" font-weight="bold">Static first, interactive later</text>
-  <g transform="translate(40,80)">
-    <rect x="0" y="0" width="140" height="180" rx="6" fill="#fff8eb" stroke="#a98c5a" stroke-width="2"/>
-    <rect x="10" y="20" width="120" height="100" fill="#a98c5a"/>
-    <text x="70" y="76" text-anchor="middle" font-family="sans-serif" font-size="14" fill="#fff8eb">Slide 1</text>
-    <rect x="10" y="140" width="120" height="10" fill="#f0e6d3"/>
-    <rect x="10" y="156" width="80" height="8" fill="#f0e6d3"/>
+  <rect width="400" height="300" fill="#fff"/>
+  <text x="200" y="36" text-anchor="middle" font-family="Arial, sans-serif" font-size="20" fill="#000" font-weight="bold">Static first, interactive later</text>
+  <g transform="translate(35,70)">
+    <rect x="0" y="0" width="140" height="200" fill="#fd0" stroke="#000" stroke-width="3"/>
+    <rect x="12" y="20" width="116" height="100" fill="#0085f1"/>
+    <text x="70" y="76" text-anchor="middle" font-family="Arial, sans-serif" font-size="14" fill="#fff" font-weight="bold">Slide 1</text>
+    <rect x="12" y="140" width="116" height="10" fill="#000"/>
+    <rect x="12" y="156" width="76" height="8" fill="#000"/>
+    <text x="70" y="190" text-anchor="middle" font-family="Arial, sans-serif" font-size="11" fill="#000">static (HTML only)</text>
   </g>
-  <g stroke="#a98c5a" stroke-width="3" fill="none" stroke-linecap="round">
-    <path d="M195 170 L235 170" />
-    <polygon points="235,165 247,170 235,175" fill="#a98c5a"/>
+  <g stroke="#000" stroke-width="3" fill="none" stroke-linecap="round">
+    <path d="M185 165 L215 165"/>
   </g>
-  <g transform="translate(255,80)">
-    <rect x="0" y="0" width="140" height="180" rx="6" fill="#fff8eb" stroke="#a98c5a" stroke-width="2"/>
-    <rect x="10" y="20" width="120" height="100" fill="#a98c5a"/>
-    <text x="70" y="76" text-anchor="middle" font-family="sans-serif" font-size="14" fill="#fff8eb">1 / 5</text>
-    <circle cx="40" cy="135" r="3" fill="#a98c5a"/>
-    <circle cx="55" cy="135" r="3" fill="#f0e6d3"/>
-    <circle cx="70" cy="135" r="3" fill="#f0e6d3"/>
-    <circle cx="85" cy="135" r="3" fill="#f0e6d3"/>
-    <circle cx="100" cy="135" r="3" fill="#f0e6d3"/>
-    <polygon points="20,70 8,60 8,80" fill="#a98c5a"/>
-    <polygon points="120,70 132,60 132,80" fill="#a98c5a"/>
-    <rect x="10" y="150" width="120" height="10" fill="#f0e6d3"/>
-    <rect x="10" y="166" width="80" height="8" fill="#f0e6d3"/>
+  <polygon points="215,160 230,165 215,170" fill="#000"/>
+  <g transform="translate(225,70)">
+    <rect x="0" y="0" width="140" height="200" fill="#ffa400" stroke="#000" stroke-width="3"/>
+    <rect x="12" y="20" width="116" height="100" fill="#0085f1"/>
+    <text x="70" y="76" text-anchor="middle" font-family="Arial, sans-serif" font-size="14" fill="#fff" font-weight="bold">1 / 5</text>
+    <polygon points="22,70 10,60 10,80" fill="#fff" stroke="#000" stroke-width="2"/>
+    <polygon points="118,70 130,60 130,80" fill="#fff" stroke="#000" stroke-width="2"/>
+    <circle cx="42" cy="135" r="4" fill="#000"/>
+    <circle cx="58" cy="135" r="4" fill="#fff" stroke="#000" stroke-width="1.5"/>
+    <circle cx="74" cy="135" r="4" fill="#fff" stroke="#000" stroke-width="1.5"/>
+    <circle cx="90" cy="135" r="4" fill="#fff" stroke="#000" stroke-width="1.5"/>
+    <circle cx="106" cy="135" r="4" fill="#fff" stroke="#000" stroke-width="1.5"/>
+    <rect x="12" y="150" width="116" height="10" fill="#000"/>
+    <rect x="12" y="166" width="76" height="8" fill="#000"/>
+    <text x="70" y="190" text-anchor="middle" font-family="Arial, sans-serif" font-size="11" fill="#000">interactive (after JS)</text>
   </g>
 </svg>

--- a/src/assets/convert_on_arrival_thumbnail.svg
+++ b/src/assets/convert_on_arrival_thumbnail.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 300" width="400" height="300">
+  <rect width="400" height="300" fill="#fff4de"/>
+  <text x="200" y="36" text-anchor="middle" font-family="sans-serif" font-size="20" fill="#5a4a2e" font-weight="bold">Static first, interactive later</text>
+  <g transform="translate(40,80)">
+    <rect x="0" y="0" width="140" height="180" rx="6" fill="#fff8eb" stroke="#a98c5a" stroke-width="2"/>
+    <rect x="10" y="20" width="120" height="100" fill="#a98c5a"/>
+    <text x="70" y="76" text-anchor="middle" font-family="sans-serif" font-size="14" fill="#fff8eb">Slide 1</text>
+    <rect x="10" y="140" width="120" height="10" fill="#f0e6d3"/>
+    <rect x="10" y="156" width="80" height="8" fill="#f0e6d3"/>
+  </g>
+  <g stroke="#a98c5a" stroke-width="3" fill="none" stroke-linecap="round">
+    <path d="M195 170 L235 170" />
+    <polygon points="235,165 247,170 235,175" fill="#a98c5a"/>
+  </g>
+  <g transform="translate(255,80)">
+    <rect x="0" y="0" width="140" height="180" rx="6" fill="#fff8eb" stroke="#a98c5a" stroke-width="2"/>
+    <rect x="10" y="20" width="120" height="100" fill="#a98c5a"/>
+    <text x="70" y="76" text-anchor="middle" font-family="sans-serif" font-size="14" fill="#fff8eb">1 / 5</text>
+    <circle cx="40" cy="135" r="3" fill="#a98c5a"/>
+    <circle cx="55" cy="135" r="3" fill="#f0e6d3"/>
+    <circle cx="70" cy="135" r="3" fill="#f0e6d3"/>
+    <circle cx="85" cy="135" r="3" fill="#f0e6d3"/>
+    <circle cx="100" cy="135" r="3" fill="#f0e6d3"/>
+    <polygon points="20,70 8,60 8,80" fill="#a98c5a"/>
+    <polygon points="120,70 132,60 132,80" fill="#a98c5a"/>
+    <rect x="10" y="150" width="120" height="10" fill="#f0e6d3"/>
+    <rect x="10" y="166" width="80" height="8" fill="#f0e6d3"/>
+  </g>
+</svg>

--- a/src/assets/convert_on_arrival_thumbnail.svg
+++ b/src/assets/convert_on_arrival_thumbnail.svg
@@ -9,9 +9,9 @@
     <text x="70" y="190" text-anchor="middle" font-family="Arial, sans-serif" font-size="11" fill="#000">static (HTML only)</text>
   </g>
   <g stroke="#000" stroke-width="3" fill="none" stroke-linecap="round">
-    <path d="M185 165 L215 165"/>
+    <path d="M185 165 L200 165"/>
   </g>
-  <polygon points="215,160 230,165 215,170" fill="#000"/>
+  <polygon points="200,160 215,165 200,170" fill="#000"/>
   <g transform="translate(225,70)">
     <rect x="0" y="0" width="140" height="200" fill="#ffa400" stroke="#000" stroke-width="3"/>
     <rect x="12" y="20" width="116" height="100" fill="#0085f1"/>

--- a/src/assets/convert_on_arrival_thumbnail.svg
+++ b/src/assets/convert_on_arrival_thumbnail.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 50 400 240" width="400" height="240">
   <rect width="400" height="300" fill="#fff"/>
   <g transform="translate(35,70)">
-    <rect x="0" y="0" width="140" height="200" fill="#fd0" stroke="#000" stroke-width="3"/>
+    <rect x="0" y="0" width="140" height="200" fill="#fff" stroke="#000" stroke-width="3"/>
     <rect x="12" y="20" width="116" height="100" fill="#0085f1"/>
     <text x="70" y="76" text-anchor="middle" font-family="Arial, sans-serif" font-size="14" fill="#fff" font-weight="bold">Slide 1</text>
     <rect x="12" y="140" width="116" height="10" fill="#000"/>
@@ -13,7 +13,7 @@
   </g>
   <polygon points="200,160 215,165 200,170" fill="#000"/>
   <g transform="translate(225,70)">
-    <rect x="0" y="0" width="140" height="200" fill="#ffa400" stroke="#000" stroke-width="3"/>
+    <rect x="0" y="0" width="140" height="200" fill="#fff" stroke="#000" stroke-width="3"/>
     <rect x="12" y="20" width="116" height="100" fill="#0085f1"/>
     <text x="70" y="76" text-anchor="middle" font-family="Arial, sans-serif" font-size="14" fill="#fff" font-weight="bold">1 / 5</text>
     <polygon points="22,70 10,60 10,80" fill="#fff" stroke="#000" stroke-width="2"/>

--- a/src/assets/convert_on_arrival_thumbnail.svg
+++ b/src/assets/convert_on_arrival_thumbnail.svg
@@ -4,8 +4,8 @@
     <rect x="0" y="0" width="140" height="200" fill="#fff" stroke="#000" stroke-width="3"/>
     <rect x="12" y="20" width="116" height="100" fill="#0085f1"/>
     <text x="70" y="76" text-anchor="middle" font-family="Arial, sans-serif" font-size="14" fill="#fff" font-weight="bold">Slide 1</text>
-    <rect x="12" y="140" width="116" height="10" fill="#000"/>
-    <rect x="12" y="156" width="76" height="8" fill="#000"/>
+    <rect x="12" y="150" width="116" height="10" fill="#000"/>
+    <rect x="12" y="166" width="76" height="8" fill="#000"/>
     <text x="70" y="190" text-anchor="middle" font-family="Arial, sans-serif" font-size="11" fill="#000">static (HTML only)</text>
   </g>
   <g stroke="#000" stroke-width="3" fill="none" stroke-linecap="round">

--- a/src/assets/convert_on_arrival_thumbnail.svg
+++ b/src/assets/convert_on_arrival_thumbnail.svg
@@ -1,6 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 300" width="400" height="300">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 50 400 240" width="400" height="240">
   <rect width="400" height="300" fill="#fff"/>
-  <text x="200" y="36" text-anchor="middle" font-family="Arial, sans-serif" font-size="20" fill="#000" font-weight="bold">Static first, interactive later</text>
   <g transform="translate(35,70)">
     <rect x="0" y="0" width="140" height="200" fill="#fd0" stroke="#000" stroke-width="3"/>
     <rect x="12" y="20" width="116" height="100" fill="#0085f1"/>

--- a/src/patterns/convert_on_arrival.md
+++ b/src/patterns/convert_on_arrival.md
@@ -5,6 +5,7 @@ tags: pattern
 thumbnail: /assets/convert_on_arrival_thumbnail.svg
 og_image: /assets/speed_patterns_og_image.jpg
 order: 5
+ai_assisted: true
 date: 2017-12-04
 authors:
     - name: Sergey Chernyshev

--- a/src/patterns/convert_on_arrival.md
+++ b/src/patterns/convert_on_arrival.md
@@ -28,46 +28,46 @@ Render the simplest possible static representation of the component immediately,
 
 For a carousel:
 
-1. Render the **first slide** as a plain image (or HTML block) at the correct dimensions.
-2. Once the carousel JavaScript and remaining slides are downloaded, **convert** the static element into the full interactive carousel — without any layout shift.
-3. The transition from static to interactive should be visually invisible to the user.
+1. Render the **first slide** as a plain image (or HTML block) at the correct dimensions
+2. Once the carousel JavaScript and remaining slides are downloaded, **convert** the static element into the full interactive carousel — without any layout shift
+3. The transition from static to interactive should be visually invisible to the user
 
 The same pattern applies broadly:
 
-- **Video players** — show the poster image with a play button immediately; load the player on click or when idle.
-- **Maps** — show a static map tile or screenshot first; swap for an interactive map when the library loads.
-- **Tabbed panels** — render the active tab's content as plain HTML; attach tab-switching behavior later.
-- **Tables with sort/filter** — render the rows server-side; attach client-side controls progressively.
+- **Video players** — show the poster image with a play button immediately; load the player on click or when idle
+- **Maps** — show a static map tile or screenshot first; swap for an interactive map when the library loads
+- **Tabbed panels** — render the active tab's content as plain HTML; attach tab-switching behavior later
+- **Tables with sort/filter** — render the rows server-side; attach client-side controls progressively
 
 ## Why This Works
 
 The dominant use of an interactive component is often passive consumption of its default state. By optimizing for that default state, you get:
 
-- **Faster first paint** — no JavaScript blocks the initial render.
-- **Faster Largest Contentful Paint (LCP)** — the hero image arrives in the first HTML response.
-- **No layout shift** — sizes are fixed in the static markup before any code runs.
-- **Resilience** — if scripts fail or are slow, the user still sees usable content.
+- **Faster first paint** — no JavaScript blocks the initial render
+- **Faster Largest Contentful Paint (LCP)** — the hero image arrives in the first HTML response
+- **No layout shift** — sizes are fixed in the static markup before any code runs
+- **Resilience** — if scripts fail or are slow, the user still sees usable content
 
 ## Guidelines
 
-- **Match dimensions exactly.** The static placeholder must occupy the same space as the final component to avoid [layout shift](/patterns/immutable_layout/).
-- **Make the static state useful, not decorative.** It should be the real first slide, the real hero image, the real default tab — not a generic placeholder.
-- **Don't compete with the critical path.** The upgrade should wait until the rest of the page is settled, so it doesn't fight for resources during the most important part of load.
-- **Test the static-only experience.** Disable JavaScript and confirm the page is still presentable and on-brand.
+- **Match dimensions exactly.** The static placeholder must occupy the same space as the final component to avoid [layout shift](/patterns/immutable_layout/)
+- **Make the static state useful, not decorative.** It should be the real first slide, the real hero image, the real default tab — not a generic placeholder
+- **Don't compete with the critical path.** The upgrade should wait until the rest of the page is settled, so it doesn't fight for resources during the most important part of load
+- **Test the static-only experience.** Disable JavaScript and confirm the page is still presentable and on-brand
 
 ## Related Patterns
 
-- [Fast Start](/patterns/fast_start/) — getting that first paint up quickly is what makes this pattern pay off.
-- [Immutable Layout](/patterns/immutable_layout/) — the upgrade must not shift the page.
-- [Skeletal Designs](/patterns/skeletal_designs/) — for parts of the UI where no useful static representation exists.
+- [Fast Start](/patterns/fast_start/) — getting that first paint up quickly is what makes this pattern pay off
+- [Immutable Layout](/patterns/immutable_layout/) — the upgrade must not shift the page
+- [Skeletal Designs](/patterns/skeletal_designs/) — for parts of the UI where no useful static representation exists
 
 ## Technical Implementation
 
 Defer the upgrade until the page is no longer fighting for resources. Useful primitives:
 
-- `requestIdleCallback` — schedule the upgrade for an idle slice of the main thread.
-- `IntersectionObserver` — only upgrade components that are actually visible (or about to be).
-- Interaction-based loading — wait until the user hovers, focuses, or clicks the static placeholder before downloading the heavier interactive code.
-- Dynamic `import()` — code-split the interactive implementation so it isn't part of the critical bundle.
+- `requestIdleCallback` — schedule the upgrade for an idle slice of the main thread
+- `IntersectionObserver` — only upgrade components that are actually visible (or about to be)
+- Interaction-based loading — wait until the user hovers, focuses, or clicks the static placeholder before downloading the heavier interactive code
+- Dynamic `import()` — code-split the interactive implementation so it isn't part of the critical bundle
 
 The static placeholder should be authored as plain HTML at the correct final dimensions; the upgrade script then mounts the interactive version into (or in place of) that container without changing its size.

--- a/src/patterns/convert_on_arrival.md
+++ b/src/patterns/convert_on_arrival.md
@@ -1,0 +1,62 @@
+---
+layout: article.njk
+title: Convert on Arrival
+tags: pattern
+thumbnail: /assets/convert_on_arrival_thumbnail.svg
+og_image: /assets/speed_patterns_og_image.jpg
+order: 5
+---
+
+Rich interactive components — carousels, tabbed panels, video players, maps, comparison sliders — are valuable, but they bring along a lot of code and data. Waiting for all of it to load before showing anything leaves the user staring at a blank container.
+
+<!-- excerpt -->
+
+## The Problem
+
+A typical "above the fold" carousel illustrates the issue well. To work, it needs:
+
+- Multiple images (or video frames)
+- JavaScript for navigation, touch handling and autoplay
+- CSS for layout and transitions
+- Often, font and analytics dependencies
+
+Until all of that arrives, the user either sees nothing, sees a spinner, or sees a janky half-loaded version that shifts as code initializes. Yet 90% of the visible value of a carousel is its first slide — the one the user sees on arrival.
+
+## Solution
+
+Render the simplest possible static representation of the component immediately, using only HTML and CSS. Then progressively enhance it into the full interactive version as the supporting code and data arrive.
+
+For a carousel:
+
+1. Render the **first slide** as a plain image (or HTML block) at the correct dimensions.
+2. Once the carousel JavaScript and remaining slides are downloaded, **convert** the static element into the full interactive carousel — without any layout shift.
+3. The transition from static to interactive should be visually invisible to the user.
+
+The same pattern applies broadly:
+
+- **Video players** — show the poster image with a play button immediately; load the player on click or when idle.
+- **Maps** — show a static map tile or screenshot first; swap for an interactive map when the library loads.
+- **Tabbed panels** — render the active tab's content as plain HTML; attach tab-switching behavior later.
+- **Tables with sort/filter** — render the rows server-side; attach client-side controls progressively.
+
+## Why This Works
+
+The dominant use of an interactive component is often passive consumption of its default state. By optimizing for that default state, you get:
+
+- **Faster first paint** — no JavaScript blocks the initial render.
+- **Faster Largest Contentful Paint (LCP)** — the hero image arrives in the first HTML response.
+- **No layout shift** — sizes are fixed in the static markup before any code runs.
+- **Resilience** — if scripts fail or are slow, the user still sees usable content.
+
+## Guidelines
+
+- **Match dimensions exactly.** The static placeholder must occupy the same space as the final component to avoid [layout shift](/patterns/immutable_layout/).
+- **Make the static state useful, not decorative.** It should be the real first slide, the real hero image, the real default tab — not a generic placeholder.
+- **Defer the upgrade.** Use `requestIdleCallback`, `IntersectionObserver`, or interaction-based loading so you don't block the main thread fighting for the same resources as the rest of the page.
+- **Test the static-only experience.** Disable JavaScript and confirm the page is still presentable and on-brand.
+
+## Related Patterns
+
+- [Fast Start](/patterns/fast_start/) — getting that first paint up quickly is what makes this pattern pay off.
+- [Immutable Layout](/patterns/immutable_layout/) — the upgrade must not shift the page.
+- [Skeletal Designs](/patterns/skeletal_designs/) — for parts of the UI where no useful static representation exists.

--- a/src/patterns/convert_on_arrival.md
+++ b/src/patterns/convert_on_arrival.md
@@ -5,6 +5,10 @@ tags: pattern
 thumbnail: /assets/convert_on_arrival_thumbnail.svg
 og_image: /assets/speed_patterns_og_image.jpg
 order: 5
+date: 2017-12-04
+authors:
+    - name: Sergey Chernyshev
+      url: https://www.sergeychernyshev.com/
 ---
 
 Rich interactive components — carousels, tabbed panels, video players, maps, comparison sliders — are valuable, but they bring along a lot of code and data. Waiting for all of it to load before showing anything leaves the user staring at a blank container.

--- a/src/patterns/convert_on_arrival.md
+++ b/src/patterns/convert_on_arrival.md
@@ -24,6 +24,11 @@ Until all of that arrives, the user either sees nothing, sees a spinner, or sees
 
 ## Solution
 
+<figure>
+<figcaption>The static placeholder ships in the first HTML response; the carousel "converts" into its full interactive form once the supporting code arrives, without changing size.</figcaption>
+<img src="/assets/convert_on_arrival_thumbnail.svg" width="400" alt="Two carousel panels side by side: the left shows a single static slide labeled 'Slide 1', the right shows the same panel as a fully interactive carousel with arrows, position dots and a counter '1 / 5'"/>
+</figure>
+
 Render the simplest possible static representation of the component immediately, using only HTML and CSS. Then progressively enhance it into the full interactive version as the supporting code and data arrive.
 
 For a carousel:

--- a/src/patterns/convert_on_arrival.md
+++ b/src/patterns/convert_on_arrival.md
@@ -27,8 +27,8 @@ Until all of that arrives, the user either sees nothing, sees a spinner, or sees
 The static placeholder ships in the first HTML response; the carousel "converts" into its full interactive form once the supporting code arrives, without changing size.
 
 <figure>
-<figcaption>Static first, interactive later</figcaption>
 <img src="/assets/convert_on_arrival_thumbnail.svg" width="400" alt="Two carousel panels side by side: the left shows a single static slide labeled 'Slide 1', the right shows the same panel as a fully interactive carousel with arrows, position dots and a counter '1 / 5'"/>
+<figcaption>Static first, interactive later</figcaption>
 </figure>
 
 Render the simplest possible static representation of the component immediately, using only HTML and CSS. Then progressively enhance it into the full interactive version as the supporting code and data arrive.

--- a/src/patterns/convert_on_arrival.md
+++ b/src/patterns/convert_on_arrival.md
@@ -27,7 +27,7 @@ Until all of that arrives, the user either sees nothing, sees a spinner, or sees
 The static placeholder ships in the first HTML response; the carousel "converts" into its full interactive form once the supporting code arrives, without changing size.
 
 <figure>
-<img src="/assets/convert_on_arrival_thumbnail.svg" width="400" alt="Two carousel panels side by side: the left shows a single static slide labeled 'Slide 1', the right shows the same panel as a fully interactive carousel with arrows, position dots and a counter '1 / 5'"/>
+<img src="/assets/convert_on_arrival_thumbnail.svg" width="520" alt="Two carousel panels side by side: the left shows a single static slide labeled 'Slide 1', the right shows the same panel as a fully interactive carousel with arrows, position dots and a counter '1 / 5'"/>
 <figcaption>Static first, interactive later</figcaption>
 </figure>
 

--- a/src/patterns/convert_on_arrival.md
+++ b/src/patterns/convert_on_arrival.md
@@ -24,8 +24,10 @@ Until all of that arrives, the user either sees nothing, sees a spinner, or sees
 
 ## Solution
 
+The static placeholder ships in the first HTML response; the carousel "converts" into its full interactive form once the supporting code arrives, without changing size.
+
 <figure>
-<figcaption>The static placeholder ships in the first HTML response; the carousel "converts" into its full interactive form once the supporting code arrives, without changing size.</figcaption>
+<figcaption>Static first, interactive later</figcaption>
 <img src="/assets/convert_on_arrival_thumbnail.svg" width="400" alt="Two carousel panels side by side: the left shows a single static slide labeled 'Slide 1', the right shows the same panel as a fully interactive carousel with arrows, position dots and a counter '1 / 5'"/>
 </figure>
 

--- a/src/patterns/convert_on_arrival.md
+++ b/src/patterns/convert_on_arrival.md
@@ -52,7 +52,7 @@ The dominant use of an interactive component is often passive consumption of its
 
 - **Match dimensions exactly.** The static placeholder must occupy the same space as the final component to avoid [layout shift](/patterns/immutable_layout/).
 - **Make the static state useful, not decorative.** It should be the real first slide, the real hero image, the real default tab — not a generic placeholder.
-- **Defer the upgrade.** Use `requestIdleCallback`, `IntersectionObserver`, or interaction-based loading so you don't block the main thread fighting for the same resources as the rest of the page.
+- **Don't compete with the critical path.** The upgrade should wait until the rest of the page is settled, so it doesn't fight for resources during the most important part of load.
 - **Test the static-only experience.** Disable JavaScript and confirm the page is still presentable and on-brand.
 
 ## Related Patterns
@@ -60,3 +60,14 @@ The dominant use of an interactive component is often passive consumption of its
 - [Fast Start](/patterns/fast_start/) — getting that first paint up quickly is what makes this pattern pay off.
 - [Immutable Layout](/patterns/immutable_layout/) — the upgrade must not shift the page.
 - [Skeletal Designs](/patterns/skeletal_designs/) — for parts of the UI where no useful static representation exists.
+
+## Technical Implementation
+
+Defer the upgrade until the page is no longer fighting for resources. Useful primitives:
+
+- `requestIdleCallback` — schedule the upgrade for an idle slice of the main thread.
+- `IntersectionObserver` — only upgrade components that are actually visible (or about to be).
+- Interaction-based loading — wait until the user hovers, focuses, or clicks the static placeholder before downloading the heavier interactive code.
+- Dynamic `import()` — code-split the interactive implementation so it isn't part of the critical bundle.
+
+The static placeholder should be authored as plain HTML at the correct final dimensions; the upgrade script then mounts the interactive version into (or in place of) that container without changing its size.

--- a/src/patterns/convert_on_arrival.md
+++ b/src/patterns/convert_on_arrival.md
@@ -42,7 +42,7 @@ For a carousel:
 
 1. Render the **first slide** as a plain image (or HTML block) at the correct dimensions
 2. Once the carousel JavaScript and remaining slides are downloaded, **convert** the static element into the full interactive carousel — without any layout shift
-3. The transition from static to interactive should be visually invisible to the user
+3. The transition from static to interactive should be virtually invisible to the user
 
 The same pattern applies broadly:
 
@@ -81,5 +81,6 @@ Defer the upgrade until the page is no longer fighting for resources. Useful pri
 - `IntersectionObserver` — only upgrade components that are actually visible (or about to be)
 - Interaction-based loading — wait until the user hovers, focuses, or clicks the static placeholder before downloading the heavier interactive code
 - Dynamic `import()` — code-split the interactive implementation so it isn't part of the critical bundle
+- Static HTML and CSS implementation wrapped in a [custom element](https://developer.mozilla.org/en-US/docs/Web/API/Web_components/Using_custom_elements). CSS can use `my-component:not(:defined)` for styles that should only be applied before interactivity.
 
 The static placeholder should be authored as plain HTML at the correct final dimensions; the upgrade script then mounts the interactive version into (or in place of) that container without changing its size.


### PR DESCRIPTION
## Summary
- Adds a new pattern article describing how to render a static placeholder version of complex interactive components (carousels, video players, maps) and progressively upgrade them as code and data arrive.
- Includes a simple SVG thumbnail and reuses the site-wide OG image.

Closes #2

## Test plan
- [x] Run `npm run start` and verify the article renders at `/patterns/convert_on_arrival/`
- [x] Confirm the new pattern appears in the homepage list with thumbnail
- [x] Confirm the new pattern shows up in the side nav

🤖 Generated with [Claude Code](https://claude.com/claude-code)