### PR TITLE
Add Enhance Fonts As They Load pattern

### DIFF
--- a/src/assets/enhance_fonts_thumbnail.svg
+++ b/src/assets/enhance_fonts_thumbnail.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 50 400 240" width="400" height="240">
   <rect width="400" height="300" fill="#fff"/>
   <g transform="translate(35,70)">
-    <rect x="0" y="0" width="140" height="200" fill="#fd0" stroke="#000" stroke-width="3"/>
+    <rect x="0" y="0" width="140" height="200" fill="#fff" stroke="#000" stroke-width="3"/>
     <text x="70" y="70" text-anchor="middle" font-family="Arial, sans-serif" font-size="22" fill="#000" font-weight="bold">Headline</text>
     <text x="70" y="100" text-anchor="middle" font-family="Arial, sans-serif" font-size="11" fill="#000">readable system text</text>
     <text x="70" y="120" text-anchor="middle" font-family="Arial, sans-serif" font-size="11" fill="#000">while custom fonts load</text>
@@ -12,7 +12,7 @@
   </g>
   <polygon points="200,160 215,165 200,170" fill="#000"/>
   <g transform="translate(225,70)">
-    <rect x="0" y="0" width="140" height="200" fill="#ffa400" stroke="#000" stroke-width="3"/>
+    <rect x="0" y="0" width="140" height="200" fill="#fff" stroke="#000" stroke-width="3"/>
     <text x="70" y="70" text-anchor="middle" font-family="Georgia, serif" font-size="22" fill="#000" font-weight="bold" font-style="italic">Headline</text>
     <text x="70" y="100" text-anchor="middle" font-family="Georgia, serif" font-size="11" fill="#000" font-style="italic">readable system text</text>
     <text x="70" y="120" text-anchor="middle" font-family="Georgia, serif" font-size="11" fill="#000" font-style="italic">while custom fonts load</text>

--- a/src/assets/enhance_fonts_thumbnail.svg
+++ b/src/assets/enhance_fonts_thumbnail.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 300" width="400" height="300">
+  <rect width="400" height="300" fill="#fff4de"/>
+  <text x="200" y="38" text-anchor="middle" font-family="sans-serif" font-size="20" fill="#5a4a2e" font-weight="bold">System first, custom later</text>
+  <g transform="translate(40,80)">
+    <rect x="0" y="0" width="140" height="180" rx="6" fill="#fff8eb" stroke="#a98c5a" stroke-width="2"/>
+    <text x="70" y="60" text-anchor="middle" font-family="Arial, sans-serif" font-size="22" fill="#5a4a2e" font-weight="bold">Headline</text>
+    <text x="70" y="90" text-anchor="middle" font-family="Arial, sans-serif" font-size="11" fill="#5a4a2e">readable system text</text>
+    <text x="70" y="115" text-anchor="middle" font-family="Arial, sans-serif" font-size="11" fill="#5a4a2e">while custom fonts load</text>
+    <text x="70" y="160" text-anchor="middle" font-family="Arial, sans-serif" font-size="9" fill="#a98c5a">fallback (system)</text>
+  </g>
+  <g stroke="#a98c5a" stroke-width="3" fill="none" stroke-linecap="round">
+    <path d="M195 170 L235 170" />
+    <polygon points="235,165 247,170 235,175" fill="#a98c5a"/>
+  </g>
+  <g transform="translate(255,80)">
+    <rect x="0" y="0" width="140" height="180" rx="6" fill="#fff8eb" stroke="#a98c5a" stroke-width="2"/>
+    <text x="70" y="60" text-anchor="middle" font-family="Georgia, serif" font-size="22" fill="#5a4a2e" font-weight="bold" font-style="italic">Headline</text>
+    <text x="70" y="90" text-anchor="middle" font-family="Georgia, serif" font-size="11" fill="#5a4a2e" font-style="italic">readable system text</text>
+    <text x="70" y="115" text-anchor="middle" font-family="Georgia, serif" font-size="11" fill="#5a4a2e" font-style="italic">while custom fonts load</text>
+    <text x="70" y="160" text-anchor="middle" font-family="Georgia, serif" font-size="9" fill="#a98c5a" font-style="italic">custom (loaded)</text>
+  </g>
+</svg>

--- a/src/assets/enhance_fonts_thumbnail.svg
+++ b/src/assets/enhance_fonts_thumbnail.svg
@@ -8,9 +8,9 @@
     <text x="70" y="180" text-anchor="middle" font-family="Arial, sans-serif" font-size="11" fill="#000">fallback (system)</text>
   </g>
   <g stroke="#000" stroke-width="3" fill="none" stroke-linecap="round">
-    <path d="M185 165 L215 165"/>
+    <path d="M185 165 L200 165"/>
   </g>
-  <polygon points="215,160 230,165 215,170" fill="#000"/>
+  <polygon points="200,160 215,165 200,170" fill="#000"/>
   <g transform="translate(225,70)">
     <rect x="0" y="0" width="140" height="200" fill="#ffa400" stroke="#000" stroke-width="3"/>
     <text x="70" y="70" text-anchor="middle" font-family="Georgia, serif" font-size="22" fill="#000" font-weight="bold" font-style="italic">Headline</text>

--- a/src/assets/enhance_fonts_thumbnail.svg
+++ b/src/assets/enhance_fonts_thumbnail.svg
@@ -1,22 +1,22 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 300" width="400" height="300">
-  <rect width="400" height="300" fill="#fff4de"/>
-  <text x="200" y="38" text-anchor="middle" font-family="sans-serif" font-size="20" fill="#5a4a2e" font-weight="bold">System first, custom later</text>
-  <g transform="translate(40,80)">
-    <rect x="0" y="0" width="140" height="180" rx="6" fill="#fff8eb" stroke="#a98c5a" stroke-width="2"/>
-    <text x="70" y="60" text-anchor="middle" font-family="Arial, sans-serif" font-size="22" fill="#5a4a2e" font-weight="bold">Headline</text>
-    <text x="70" y="90" text-anchor="middle" font-family="Arial, sans-serif" font-size="11" fill="#5a4a2e">readable system text</text>
-    <text x="70" y="115" text-anchor="middle" font-family="Arial, sans-serif" font-size="11" fill="#5a4a2e">while custom fonts load</text>
-    <text x="70" y="160" text-anchor="middle" font-family="Arial, sans-serif" font-size="9" fill="#a98c5a">fallback (system)</text>
+  <rect width="400" height="300" fill="#fff"/>
+  <text x="200" y="36" text-anchor="middle" font-family="Arial, sans-serif" font-size="20" fill="#000" font-weight="bold">System first, custom later</text>
+  <g transform="translate(35,70)">
+    <rect x="0" y="0" width="140" height="200" fill="#fd0" stroke="#000" stroke-width="3"/>
+    <text x="70" y="70" text-anchor="middle" font-family="Arial, sans-serif" font-size="22" fill="#000" font-weight="bold">Headline</text>
+    <text x="70" y="100" text-anchor="middle" font-family="Arial, sans-serif" font-size="11" fill="#000">readable system text</text>
+    <text x="70" y="120" text-anchor="middle" font-family="Arial, sans-serif" font-size="11" fill="#000">while custom fonts load</text>
+    <text x="70" y="180" text-anchor="middle" font-family="Arial, sans-serif" font-size="11" fill="#000">fallback (system)</text>
   </g>
-  <g stroke="#a98c5a" stroke-width="3" fill="none" stroke-linecap="round">
-    <path d="M195 170 L235 170" />
-    <polygon points="235,165 247,170 235,175" fill="#a98c5a"/>
+  <g stroke="#000" stroke-width="3" fill="none" stroke-linecap="round">
+    <path d="M185 165 L215 165"/>
   </g>
-  <g transform="translate(255,80)">
-    <rect x="0" y="0" width="140" height="180" rx="6" fill="#fff8eb" stroke="#a98c5a" stroke-width="2"/>
-    <text x="70" y="60" text-anchor="middle" font-family="Georgia, serif" font-size="22" fill="#5a4a2e" font-weight="bold" font-style="italic">Headline</text>
-    <text x="70" y="90" text-anchor="middle" font-family="Georgia, serif" font-size="11" fill="#5a4a2e" font-style="italic">readable system text</text>
-    <text x="70" y="115" text-anchor="middle" font-family="Georgia, serif" font-size="11" fill="#5a4a2e" font-style="italic">while custom fonts load</text>
-    <text x="70" y="160" text-anchor="middle" font-family="Georgia, serif" font-size="9" fill="#a98c5a" font-style="italic">custom (loaded)</text>
+  <polygon points="215,160 230,165 215,170" fill="#000"/>
+  <g transform="translate(225,70)">
+    <rect x="0" y="0" width="140" height="200" fill="#ffa400" stroke="#000" stroke-width="3"/>
+    <text x="70" y="70" text-anchor="middle" font-family="Georgia, serif" font-size="22" fill="#000" font-weight="bold" font-style="italic">Headline</text>
+    <text x="70" y="100" text-anchor="middle" font-family="Georgia, serif" font-size="11" fill="#000" font-style="italic">readable system text</text>
+    <text x="70" y="120" text-anchor="middle" font-family="Georgia, serif" font-size="11" fill="#000" font-style="italic">while custom fonts load</text>
+    <text x="70" y="180" text-anchor="middle" font-family="Arial, sans-serif" font-size="11" fill="#000">custom (loaded)</text>
   </g>
 </svg>

--- a/src/assets/enhance_fonts_thumbnail.svg
+++ b/src/assets/enhance_fonts_thumbnail.svg
@@ -1,6 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 300" width="400" height="300">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 50 400 240" width="400" height="240">
   <rect width="400" height="300" fill="#fff"/>
-  <text x="200" y="36" text-anchor="middle" font-family="Arial, sans-serif" font-size="20" fill="#000" font-weight="bold">System first, custom later</text>
   <g transform="translate(35,70)">
     <rect x="0" y="0" width="140" height="200" fill="#fd0" stroke="#000" stroke-width="3"/>
     <text x="70" y="70" text-anchor="middle" font-family="Arial, sans-serif" font-size="22" fill="#000" font-weight="bold">Headline</text>

--- a/src/patterns/enhance_fonts_as_they_load.md
+++ b/src/patterns/enhance_fonts_as_they_load.md
@@ -25,7 +25,7 @@ Pure FOIT is the worse failure mode: the user can't even start reading. But a ca
 Fallback text is legible from the first paint; the branded font swaps in once it loads, without leaving the user waiting on a blank page.
 
 <figure>
-<img src="/assets/enhance_fonts_thumbnail.svg" width="400" alt="Two text panels side by side: the left in a system sans-serif labeled 'fallback (system)', the right in a serif italic labeled 'custom (loaded)'"/>
+<img src="/assets/enhance_fonts_thumbnail.svg" width="440" alt="Two text panels side by side: the left in a system sans-serif labeled 'fallback (system)', the right in a serif italic labeled 'custom (loaded)'"/>
 <figcaption>System first, custom later</figcaption>
 </figure>
 

--- a/src/patterns/enhance_fonts_as_they_load.md
+++ b/src/patterns/enhance_fonts_as_they_load.md
@@ -15,8 +15,8 @@ Custom web fonts are a powerful brand and design tool, but they cost the user ti
 
 Browsers have historically picked between two unpleasant defaults:
 
-- **FOIT — Flash of Invisible Text.** The browser hides text styled with a custom font until the font finishes loading. The user sees a layout with empty holes where the words should be. On a slow connection, the page can be visually "loaded" for several seconds with no readable content.
-- **FOUT — Flash of Unstyled Text.** The browser uses a fallback font immediately and swaps to the custom font when it loads. Text is readable from the first paint, but the swap can shift layout and feel jarring.
+- **FOIT — Flash of Invisible Text.** The browser hides text styled with a custom font until the font finishes loading. The user sees a layout with empty holes where the words should be. On a slow connection, the page can be visually "loaded" for several seconds with no readable content
+- **FOUT — Flash of Unstyled Text.** The browser uses a fallback font immediately and swaps to the custom font when it loads. Text is readable from the first paint, but the swap can shift layout and feel jarring
 
 Pure FOIT is the worse failure mode: the user can't even start reading. But a careless FOUT — a fallback font with very different metrics — is also painful.
 
@@ -26,24 +26,24 @@ Treat custom fonts as a progressive enhancement, not a render blocker. Show legi
 
 The strategy has three parts:
 
-1. **Show fallback text immediately.** Configure each web font so the browser uses a system fallback while the custom font downloads, instead of hiding the text.
-2. **Match fallback metrics to the custom font.** Pick a system fallback whose size, ascent, descent and line-height align closely with the branded font, so the swap doesn't shift layout.
-3. **Prioritize which fonts get loaded urgently.** Most pages don't need every weight and style up front. Subset, preload and self-host only what the first view actually needs.
+1. **Show fallback text immediately.** Configure each web font so the browser uses a system fallback while the custom font downloads, instead of hiding the text
+2. **Match fallback metrics to the custom font.** Pick a system fallback whose size, ascent, descent and line-height align closely with the branded font, so the swap doesn't shift layout
+3. **Prioritize which fonts get loaded urgently.** Most pages don't need every weight and style up front. Subset, preload and self-host only what the first view actually needs
 
 The first piece of legible text is what lets the user start reading. By showing fallback text immediately, you let reading begin at first paint instead of after a network round-trip. The brand fidelity arrives a moment later — at a cost of a small, near-invisible re-render rather than a blank page.
 
 ## Guidelines
 
-- **Don't block the first paint on font network requests.** Fallback text should always be visible immediately.
-- **Test with a slow network throttle.** FOIT is invisible on a fast connection. The pattern is built for the user on the slow one.
-- **Audit your font weights.** Each weight is a separate download. Many sites ship four or five weights and use two.
-- **Subset to what you actually use.** Latin-only subsets are dramatically smaller than full Unicode files; per-page subsets are smaller still.
-- **Self-host the critical fonts.** Third-party font CDNs add a DNS lookup, an extra connection and a privacy consideration.
+- **Don't block the first paint on font network requests.** Fallback text should always be visible immediately
+- **Test with a slow network throttle.** FOIT is invisible on a fast connection. The pattern is built for the user on the slow one
+- **Audit your font weights.** Each weight is a separate download. Many sites ship four or five weights and use two
+- **Subset to what you actually use.** Latin-only subsets are dramatically smaller than full Unicode files; per-page subsets are smaller still
+- **Self-host the critical fonts.** Third-party font CDNs add a DNS lookup, an extra connection and a privacy consideration
 
 ## Related Patterns
 
-- [Fast Start](/patterns/fast_start/) — fonts are one of the most common blockers of first contentful paint.
-- [Immutable Layout](/patterns/immutable_layout/) — well-tuned fallback metrics keep the swap from causing layout shift.
+- [Fast Start](/patterns/fast_start/) — fonts are one of the most common blockers of first contentful paint
+- [Immutable Layout](/patterns/immutable_layout/) — well-tuned fallback metrics keep the swap from causing layout shift
 
 ## Technical Implementation
 
@@ -59,9 +59,9 @@ The CSS `font-display` descriptor tells the browser how to behave while the cust
 }
 ```
 
-- `swap` — show fallback immediately, replace with custom font when ready. Best for branded text where the custom font is important.
-- `optional` — show fallback immediately, only use the custom font if it arrives almost instantly (otherwise stick with the fallback). Best for users on slow connections, since it eliminates layout shift after the first frame.
-- `fallback` — a compromise between the two.
+- `swap` — show fallback immediately, replace with custom font when ready. Best for branded text where the custom font is important
+- `optional` — show fallback immediately, only use the custom font if it arrives almost instantly (otherwise stick with the fallback). Best for users on slow connections, since it eliminates layout shift after the first frame
+- `fallback` — a compromise between the two
 
 Avoid the default (`auto`/`block`), which produces FOIT.
 
@@ -85,9 +85,9 @@ Tools like [Fontaine](https://github.com/unjs/fontaine) and Google's [Font Style
 
 ### Preload and use modern formats
 
-- Preload critical fonts with `<link rel="preload" as="font" type="font/woff2" crossorigin>` so the browser fetches them before discovering them in CSS.
-- Use `woff2` — it's the smallest format and supported everywhere.
-- Subset to only the characters and weights you actually use.
+- Preload critical fonts with `<link rel="preload" as="font" type="font/woff2" crossorigin>` so the browser fetches them before discovering them in CSS
+- Use `woff2` — it's the smallest format and supported everywhere
+- Subset to only the characters and weights you actually use
 
 ## Resources
 

--- a/src/patterns/enhance_fonts_as_they_load.md
+++ b/src/patterns/enhance_fonts_as_they_load.md
@@ -22,8 +22,10 @@ Pure FOIT is the worse failure mode: the user can't even start reading. But a ca
 
 ## Solution
 
+Fallback text is legible from the first paint; the branded font swaps in once it loads, without leaving the user waiting on a blank page.
+
 <figure>
-<figcaption>Fallback text is legible from the first paint; the branded font swaps in once it loads, without leaving the user waiting on a blank page.</figcaption>
+<figcaption>System first, custom later</figcaption>
 <img src="/assets/enhance_fonts_thumbnail.svg" width="400" alt="Two text panels side by side: the left in a system sans-serif labeled 'fallback (system)', the right in a serif italic labeled 'custom (loaded)'"/>
 </figure>
 

--- a/src/patterns/enhance_fonts_as_they_load.md
+++ b/src/patterns/enhance_fonts_as_they_load.md
@@ -1,0 +1,85 @@
+---
+layout: article.njk
+title: Enhance Fonts As They Load
+tags: pattern
+thumbnail: /assets/enhance_fonts_thumbnail.svg
+og_image: /assets/speed_patterns_og_image.jpg
+order: 6
+---
+
+Custom web fonts are a powerful brand and design tool, but they cost the user time. A font file has to be downloaded, parsed and applied before any text styled with it can be rendered. Until then, the browser must decide what to do — and the wrong default ruins the reading experience.
+
+<!-- excerpt -->
+
+## The Problem: FOIT and FOUT
+
+Browsers have historically picked between two unpleasant defaults:
+
+- **FOIT — Flash of Invisible Text.** The browser hides text styled with a custom font until the font finishes loading. The user sees a layout with empty holes where the words should be. On a slow connection, the page can be visually "loaded" for several seconds with no readable content.
+- **FOUT — Flash of Unstyled Text.** The browser uses a fallback font immediately and swaps to the custom font when it loads. Text is readable from the first paint, but the swap can shift layout and feel jarring.
+
+Pure FOIT is the worse failure mode: the user can't even start reading. But a careless FOUT — a fallback font with very different metrics — is also painful.
+
+## Solution
+
+Treat custom fonts as a progressive enhancement, not a render blocker. Show legible fallback text from the first paint, then upgrade to the branded font when it arrives. Choose the fallback so the swap is as imperceptible as possible.
+
+### 1. Use `font-display: swap` (or `optional`)
+
+The CSS `font-display` descriptor tells the browser how to behave while the custom font loads:
+
+```css
+@font-face {
+  font-family: "BrandSans";
+  src: url("/fonts/BrandSans.woff2") format("woff2");
+  font-display: swap;
+}
+```
+
+- `swap` — show fallback immediately, replace with custom font when ready. Best for branded text where the custom font is important.
+- `optional` — show fallback immediately, only use the custom font if it arrives almost instantly (otherwise stick with the fallback). Best for users on slow connections, since it eliminates layout shift after the first frame.
+- `fallback` — a compromise between the two.
+
+Avoid the default (`auto`/`block`), which produces FOIT.
+
+### 2. Match fallback metrics to the custom font
+
+When the swap happens, lines may rewrap, headings may shift, and Cumulative Layout Shift increases. Modern CSS makes this almost solvable:
+
+```css
+@font-face {
+  font-family: "BrandSans";
+  src: url("/fonts/BrandSans.woff2") format("woff2");
+  font-display: swap;
+  size-adjust: 102%;
+  ascent-override: 95%;
+  descent-override: 22%;
+  line-gap-override: 0%;
+}
+```
+
+Tools like [Fontaine](https://github.com/unjs/fontaine) and Google's [Font Style Matcher](https://meowni.ca/font-style-matcher/) help find values that make a system fallback nearly indistinguishable in metrics from your branded font.
+
+### 3. Prioritize the right fonts
+
+Custom fonts are not free, even when handled well. Consider:
+
+- **Self-host** rather than relying on third-party font CDNs — this eliminates an extra DNS lookup and connection.
+- **Preload critical fonts** with `<link rel="preload" as="font" type="font/woff2" crossorigin>` so the browser fetches them before discovering them in CSS.
+- **Subset your fonts** to only the characters and weights you actually use.
+- **Use `woff2`** — it's the smallest format and supported everywhere.
+
+## Why This Works
+
+Reading begins with the first piece of legible text. By showing fallback text immediately, you let the user start reading at first paint instead of waiting for a network round-trip. The brand fidelity arrives a moment later — at a cost of a small, near-invisible re-render rather than a blank page.
+
+## Related Patterns
+
+- [Fast Start](/patterns/fast_start/) — fonts are one of the most common blockers of first contentful paint.
+- [Immutable Layout](/patterns/immutable_layout/) — well-tuned fallback metrics keep the swap from causing layout shift.
+
+## Resources
+
+- [`font-display` on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display)
+- [Font Style Matcher](https://meowni.ca/font-style-matcher/) by Monica Dinculescu
+- [Improved font fallbacks (web.dev)](https://web.dev/articles/css-size-adjust)

--- a/src/patterns/enhance_fonts_as_they_load.md
+++ b/src/patterns/enhance_fonts_as_they_load.md
@@ -5,6 +5,10 @@ tags: pattern
 thumbnail: /assets/enhance_fonts_thumbnail.svg
 og_image: /assets/speed_patterns_og_image.jpg
 order: 6
+date: 2017-12-04
+authors:
+    - name: Sergey Chernyshev
+      url: https://www.sergeychernyshev.com/
 ---
 
 Custom web fonts are a powerful brand and design tool, but they cost the user time. A font file has to be downloaded, parsed and applied before any text styled with it can be rendered. Until then, the browser must decide what to do — and the wrong default ruins the reading experience.

--- a/src/patterns/enhance_fonts_as_they_load.md
+++ b/src/patterns/enhance_fonts_as_they_load.md
@@ -22,6 +22,11 @@ Pure FOIT is the worse failure mode: the user can't even start reading. But a ca
 
 ## Solution
 
+<figure>
+<figcaption>Fallback text is legible from the first paint; the branded font swaps in once it loads, without leaving the user waiting on a blank page.</figcaption>
+<img src="/assets/enhance_fonts_thumbnail.svg" width="400" alt="Two text panels side by side: the left in a system sans-serif labeled 'fallback (system)', the right in a serif italic labeled 'custom (loaded)'"/>
+</figure>
+
 Treat custom fonts as a progressive enhancement, not a render blocker. Show legible fallback text from the first paint, then upgrade to the branded font when it arrives. Choose the fallback so the swap is as imperceptible as possible.
 
 The strategy has three parts:

--- a/src/patterns/enhance_fonts_as_they_load.md
+++ b/src/patterns/enhance_fonts_as_they_load.md
@@ -25,8 +25,8 @@ Pure FOIT is the worse failure mode: the user can't even start reading. But a ca
 Fallback text is legible from the first paint; the branded font swaps in once it loads, without leaving the user waiting on a blank page.
 
 <figure>
-<figcaption>System first, custom later</figcaption>
 <img src="/assets/enhance_fonts_thumbnail.svg" width="400" alt="Two text panels side by side: the left in a system sans-serif labeled 'fallback (system)', the right in a serif italic labeled 'custom (loaded)'"/>
+<figcaption>System first, custom later</figcaption>
 </figure>
 
 Treat custom fonts as a progressive enhancement, not a render blocker. Show legible fallback text from the first paint, then upgrade to the branded font when it arrives. Choose the fallback so the swap is as imperceptible as possible.

--- a/src/patterns/enhance_fonts_as_they_load.md
+++ b/src/patterns/enhance_fonts_as_they_load.md
@@ -88,7 +88,7 @@ When the swap happens, lines may rewrap, headings may shift, and Cumulative Layo
 }
 ```
 
-Tools like [Fontaine](https://github.com/unjs/fontaine) and Google's [Font Style Matcher](https://meowni.ca/font-style-matcher/) help find values that make a system fallback nearly indistinguishable in metrics from your branded font.
+Tools like [Fontaine](https://github.com/unjs/fontaine) and Monica Dinculescu's [Font Style Matcher](https://meowni.ca/font-style-matcher/) help find values that make a system fallback nearly indistinguishable in metrics from your branded font.
 
 ### Preload and use modern formats
 
@@ -99,5 +99,5 @@ Tools like [Fontaine](https://github.com/unjs/fontaine) and Google's [Font Style
 ## Resources
 
 - [`font-display` on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display)
-- [Font Style Matcher](https://meowni.ca/font-style-matcher/) by Monica Dinculescu
+- [Font Style Matcher](https://meowni.ca/font-style-matcher/) by [Monica Dinculescu](https://meowni.ca/)
 - [Improved font fallbacks (web.dev)](https://web.dev/articles/css-size-adjust)

--- a/src/patterns/enhance_fonts_as_they_load.md
+++ b/src/patterns/enhance_fonts_as_they_load.md
@@ -5,6 +5,7 @@ tags: pattern
 thumbnail: /assets/enhance_fonts_thumbnail.svg
 og_image: /assets/speed_patterns_og_image.jpg
 order: 6
+ai_assisted: true
 date: 2017-12-04
 authors:
     - name: Sergey Chernyshev

--- a/src/patterns/enhance_fonts_as_they_load.md
+++ b/src/patterns/enhance_fonts_as_they_load.md
@@ -24,7 +24,30 @@ Pure FOIT is the worse failure mode: the user can't even start reading. But a ca
 
 Treat custom fonts as a progressive enhancement, not a render blocker. Show legible fallback text from the first paint, then upgrade to the branded font when it arrives. Choose the fallback so the swap is as imperceptible as possible.
 
-### 1. Use `font-display: swap` (or `optional`)
+The strategy has three parts:
+
+1. **Show fallback text immediately.** Configure each web font so the browser uses a system fallback while the custom font downloads, instead of hiding the text.
+2. **Match fallback metrics to the custom font.** Pick a system fallback whose size, ascent, descent and line-height align closely with the branded font, so the swap doesn't shift layout.
+3. **Prioritize which fonts get loaded urgently.** Most pages don't need every weight and style up front. Subset, preload and self-host only what the first view actually needs.
+
+The first piece of legible text is what lets the user start reading. By showing fallback text immediately, you let reading begin at first paint instead of after a network round-trip. The brand fidelity arrives a moment later — at a cost of a small, near-invisible re-render rather than a blank page.
+
+## Guidelines
+
+- **Don't block the first paint on font network requests.** Fallback text should always be visible immediately.
+- **Test with a slow network throttle.** FOIT is invisible on a fast connection. The pattern is built for the user on the slow one.
+- **Audit your font weights.** Each weight is a separate download. Many sites ship four or five weights and use two.
+- **Subset to what you actually use.** Latin-only subsets are dramatically smaller than full Unicode files; per-page subsets are smaller still.
+- **Self-host the critical fonts.** Third-party font CDNs add a DNS lookup, an extra connection and a privacy consideration.
+
+## Related Patterns
+
+- [Fast Start](/patterns/fast_start/) — fonts are one of the most common blockers of first contentful paint.
+- [Immutable Layout](/patterns/immutable_layout/) — well-tuned fallback metrics keep the swap from causing layout shift.
+
+## Technical Implementation
+
+### Use `font-display`
 
 The CSS `font-display` descriptor tells the browser how to behave while the custom font loads:
 
@@ -42,7 +65,7 @@ The CSS `font-display` descriptor tells the browser how to behave while the cust
 
 Avoid the default (`auto`/`block`), which produces FOIT.
 
-### 2. Match fallback metrics to the custom font
+### Match fallback metrics
 
 When the swap happens, lines may rewrap, headings may shift, and Cumulative Layout Shift increases. Modern CSS makes this almost solvable:
 
@@ -60,23 +83,11 @@ When the swap happens, lines may rewrap, headings may shift, and Cumulative Layo
 
 Tools like [Fontaine](https://github.com/unjs/fontaine) and Google's [Font Style Matcher](https://meowni.ca/font-style-matcher/) help find values that make a system fallback nearly indistinguishable in metrics from your branded font.
 
-### 3. Prioritize the right fonts
+### Preload and use modern formats
 
-Custom fonts are not free, even when handled well. Consider:
-
-- **Self-host** rather than relying on third-party font CDNs — this eliminates an extra DNS lookup and connection.
-- **Preload critical fonts** with `<link rel="preload" as="font" type="font/woff2" crossorigin>` so the browser fetches them before discovering them in CSS.
-- **Subset your fonts** to only the characters and weights you actually use.
-- **Use `woff2`** — it's the smallest format and supported everywhere.
-
-## Why This Works
-
-Reading begins with the first piece of legible text. By showing fallback text immediately, you let the user start reading at first paint instead of waiting for a network round-trip. The brand fidelity arrives a moment later — at a cost of a small, near-invisible re-render rather than a blank page.
-
-## Related Patterns
-
-- [Fast Start](/patterns/fast_start/) — fonts are one of the most common blockers of first contentful paint.
-- [Immutable Layout](/patterns/immutable_layout/) — well-tuned fallback metrics keep the swap from causing layout shift.
+- Preload critical fonts with `<link rel="preload" as="font" type="font/woff2" crossorigin>` so the browser fetches them before discovering them in CSS.
+- Use `woff2` — it's the smallest format and supported everywhere.
+- Subset to only the characters and weights you actually use.
 
 ## Resources
 


### PR DESCRIPTION
## Summary
- Adds a new pattern article describing how to use system-font fallbacks, \`font-display: swap\` and matched metrics to avoid FOIT and minimize FOUT layout shift.
- Includes a simple SVG thumbnail and reuses the site-wide OG image.

Closes #3

## Test plan
- [ ] Run \`npm run start\` and verify the article renders at \`/patterns/enhance_fonts_as_they_load/\`
- [ ] Confirm the new pattern appears in the homepage list with thumbnail
- [ ] Confirm the new pattern shows up in the side nav

🤖 Generated with [Claude Code](https://claude.com/claude-code)