### PR TITLE
Add Acknowledge Actions pattern

### DIFF
--- a/src/assets/acknowledge_actions_thumbnail.svg
+++ b/src/assets/acknowledge_actions_thumbnail.svg
@@ -1,21 +1,21 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 300" width="400" height="300">
-  <rect width="400" height="300" fill="#fff4de"/>
-  <text x="200" y="38" text-anchor="middle" font-family="sans-serif" font-size="20" fill="#5a4a2e" font-weight="bold">Acknowledge every click</text>
-  <g transform="translate(60,90)">
-    <rect x="0" y="0" width="120" height="48" rx="6" fill="#a98c5a"/>
-    <text x="60" y="30" text-anchor="middle" font-family="sans-serif" font-size="16" fill="#fff8eb" font-weight="bold">Submit</text>
-    <text x="60" y="76" text-anchor="middle" font-family="sans-serif" font-size="11" fill="#5a4a2e">idle button</text>
+  <rect width="400" height="300" fill="#fff"/>
+  <text x="200" y="38" text-anchor="middle" font-family="Arial, sans-serif" font-size="20" fill="#000" font-weight="bold">Acknowledge every click</text>
+  <g transform="translate(40,100)">
+    <rect x="0" y="0" width="140" height="56" fill="#fd0" stroke="#000" stroke-width="3"/>
+    <text x="70" y="36" text-anchor="middle" font-family="Arial, sans-serif" font-size="18" fill="#000" font-weight="bold">Submit</text>
+    <text x="70" y="92" text-anchor="middle" font-family="Arial, sans-serif" font-size="12" fill="#000">idle button</text>
   </g>
-  <g stroke="#a98c5a" stroke-width="3" fill="none" stroke-linecap="round">
-    <path d="M195 114 L235 114" />
-    <polygon points="235,109 247,114 235,119" fill="#a98c5a"/>
+  <g stroke="#000" stroke-width="3" fill="none" stroke-linecap="round">
+    <path d="M190 128 L220 128"/>
   </g>
-  <g transform="translate(255,90)">
-    <rect x="0" y="0" width="120" height="48" rx="6" fill="#c9b48a" stroke="#a98c5a" stroke-width="2" stroke-dasharray="4 3"/>
-    <circle cx="34" cy="24" r="6" fill="none" stroke="#5a4a2e" stroke-width="2" stroke-dasharray="9 5">
-      <animateTransform attributeName="transform" type="rotate" from="0 34 24" to="360 34 24" dur="1s" repeatCount="indefinite"/>
+  <polygon points="220,123 235,128 220,133" fill="#000"/>
+  <g transform="translate(225,100)">
+    <rect x="0" y="0" width="140" height="56" fill="#ffa400" stroke="#000" stroke-width="3" stroke-dasharray="6 3"/>
+    <circle cx="32" cy="28" r="8" fill="none" stroke="#0085f1" stroke-width="3" stroke-dasharray="14 6">
+      <animateTransform attributeName="transform" type="rotate" from="0 32 28" to="360 32 28" dur="1s" repeatCount="indefinite"/>
     </circle>
-    <text x="80" y="30" text-anchor="middle" font-family="sans-serif" font-size="14" fill="#5a4a2e" font-weight="bold">Submitting…</text>
-    <text x="60" y="76" text-anchor="middle" font-family="sans-serif" font-size="11" fill="#5a4a2e">acknowledged + disabled</text>
+    <text x="86" y="34" text-anchor="middle" font-family="Arial, sans-serif" font-size="14" fill="#000" font-weight="bold">Submitting…</text>
+    <text x="70" y="92" text-anchor="middle" font-family="Arial, sans-serif" font-size="12" fill="#000">acknowledged + disabled</text>
   </g>
 </svg>

--- a/src/assets/acknowledge_actions_thumbnail.svg
+++ b/src/assets/acknowledge_actions_thumbnail.svg
@@ -1,6 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 300" width="400" height="300">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 70 400 140" width="400" height="140">
   <rect width="400" height="300" fill="#fff"/>
-  <text x="200" y="38" text-anchor="middle" font-family="Arial, sans-serif" font-size="20" fill="#000" font-weight="bold">Acknowledge every click</text>
   <g transform="translate(40,100)">
     <rect x="0" y="0" width="140" height="56" fill="#fd0" stroke="#000" stroke-width="3"/>
     <text x="70" y="36" text-anchor="middle" font-family="Arial, sans-serif" font-size="18" fill="#000" font-weight="bold">Submit</text>

--- a/src/assets/acknowledge_actions_thumbnail.svg
+++ b/src/assets/acknowledge_actions_thumbnail.svg
@@ -1,20 +1,20 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 70 400 140" width="400" height="140">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 70 400 110" width="400" height="110">
   <rect width="400" height="300" fill="#fff"/>
   <g transform="translate(40,100)">
-    <rect x="0" y="0" width="140" height="56" fill="#fd0" stroke="#000" stroke-width="3"/>
+    <text x="70" y="-8" text-anchor="middle" font-family="Arial, sans-serif" font-size="12" fill="#000">idle button</text>
+    <rect x="0" y="0" width="140" height="56" rx="6" fill="#fafafa" stroke="#888" stroke-width="1"/>
     <text x="70" y="36" text-anchor="middle" font-family="Arial, sans-serif" font-size="18" fill="#000" font-weight="bold">Submit</text>
-    <text x="70" y="92" text-anchor="middle" font-family="Arial, sans-serif" font-size="12" fill="#000">idle button</text>
   </g>
   <g stroke="#000" stroke-width="3" fill="none" stroke-linecap="round">
     <path d="M190 128 L220 128"/>
   </g>
   <polygon points="220,123 235,128 220,133" fill="#000"/>
   <g transform="translate(225,100)">
-    <rect x="0" y="0" width="140" height="56" fill="#ffa400" stroke="#000" stroke-width="3" stroke-dasharray="6 3"/>
+    <text x="70" y="-8" text-anchor="middle" font-family="Arial, sans-serif" font-size="12" fill="#000">acknowledged + disabled</text>
+    <rect x="0" y="0" width="140" height="56" rx="6" fill="#efefef" stroke="#c0c0c0" stroke-width="1"/>
     <circle cx="32" cy="28" r="8" fill="none" stroke="#0085f1" stroke-width="3" stroke-dasharray="14 6">
       <animateTransform attributeName="transform" type="rotate" from="0 32 28" to="360 32 28" dur="1s" repeatCount="indefinite"/>
     </circle>
-    <text x="86" y="34" text-anchor="middle" font-family="Arial, sans-serif" font-size="14" fill="#000" font-weight="bold">Submitting…</text>
-    <text x="70" y="92" text-anchor="middle" font-family="Arial, sans-serif" font-size="12" fill="#000">acknowledged + disabled</text>
+    <text x="86" y="34" text-anchor="middle" font-family="Arial, sans-serif" font-size="14" fill="#888" font-weight="bold">Submitting…</text>
   </g>
 </svg>

--- a/src/assets/acknowledge_actions_thumbnail.svg
+++ b/src/assets/acknowledge_actions_thumbnail.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 300" width="400" height="300">
+  <rect width="400" height="300" fill="#fff4de"/>
+  <text x="200" y="38" text-anchor="middle" font-family="sans-serif" font-size="20" fill="#5a4a2e" font-weight="bold">Acknowledge every click</text>
+  <g transform="translate(60,90)">
+    <rect x="0" y="0" width="120" height="48" rx="6" fill="#a98c5a"/>
+    <text x="60" y="30" text-anchor="middle" font-family="sans-serif" font-size="16" fill="#fff8eb" font-weight="bold">Submit</text>
+    <text x="60" y="76" text-anchor="middle" font-family="sans-serif" font-size="11" fill="#5a4a2e">idle button</text>
+  </g>
+  <g stroke="#a98c5a" stroke-width="3" fill="none" stroke-linecap="round">
+    <path d="M195 114 L235 114" />
+    <polygon points="235,109 247,114 235,119" fill="#a98c5a"/>
+  </g>
+  <g transform="translate(255,90)">
+    <rect x="0" y="0" width="120" height="48" rx="6" fill="#c9b48a" stroke="#a98c5a" stroke-width="2" stroke-dasharray="4 3"/>
+    <circle cx="34" cy="24" r="6" fill="none" stroke="#5a4a2e" stroke-width="2" stroke-dasharray="9 5">
+      <animateTransform attributeName="transform" type="rotate" from="0 34 24" to="360 34 24" dur="1s" repeatCount="indefinite"/>
+    </circle>
+    <text x="80" y="30" text-anchor="middle" font-family="sans-serif" font-size="14" fill="#5a4a2e" font-weight="bold">Submitting…</text>
+    <text x="60" y="76" text-anchor="middle" font-family="sans-serif" font-size="11" fill="#5a4a2e">acknowledged + disabled</text>
+  </g>
+</svg>

--- a/src/assets/acknowledge_actions_thumbnail.svg
+++ b/src/assets/acknowledge_actions_thumbnail.svg
@@ -12,9 +12,6 @@
   <g transform="translate(225,100)">
     <text x="70" y="-8" text-anchor="middle" font-family="Arial, sans-serif" font-size="12" fill="#000">acknowledged + disabled</text>
     <rect x="0" y="0" width="140" height="56" rx="6" fill="#efefef" stroke="#c0c0c0" stroke-width="1"/>
-    <circle cx="32" cy="28" r="8" fill="none" stroke="#0085f1" stroke-width="3" stroke-dasharray="14 6">
-      <animateTransform attributeName="transform" type="rotate" from="0 32 28" to="360 32 28" dur="1s" repeatCount="indefinite"/>
-    </circle>
-    <text x="86" y="34" text-anchor="middle" font-family="Arial, sans-serif" font-size="14" fill="#888" font-weight="bold">Submitting…</text>
+    <text x="70" y="36" text-anchor="middle" font-family="Arial, sans-serif" font-size="18" fill="#888" font-weight="bold">Submitting…</text>
   </g>
 </svg>

--- a/src/assets/acknowledge_actions_thumbnail.svg
+++ b/src/assets/acknowledge_actions_thumbnail.svg
@@ -6,9 +6,9 @@
     <text x="70" y="36" text-anchor="middle" font-family="Arial, sans-serif" font-size="18" fill="#000" font-weight="bold">Submit</text>
   </g>
   <g stroke="#000" stroke-width="3" fill="none" stroke-linecap="round">
-    <path d="M190 128 L220 128"/>
+    <path d="M190 128 L200 128"/>
   </g>
-  <polygon points="220,123 235,128 220,133" fill="#000"/>
+  <polygon points="200,123 215,128 200,133" fill="#000"/>
   <g transform="translate(225,100)">
     <text x="70" y="-8" text-anchor="middle" font-family="Arial, sans-serif" font-size="12" fill="#000">acknowledged + disabled</text>
     <rect x="0" y="0" width="140" height="56" rx="6" fill="#efefef" stroke="#c0c0c0" stroke-width="1"/>

--- a/src/patterns/acknowledge_actions.md
+++ b/src/patterns/acknowledge_actions.md
@@ -25,8 +25,10 @@ The threshold matters: research on perceived responsiveness consistently puts ro
 
 ## Solution
 
+The same control on click: idle state on the left, immediately disabled with a "Submitting…" label and inline indicator on the right.
+
 <figure>
-<figcaption>The same control on click: idle state on the left, immediately disabled with a "Submitting…" label and inline indicator on the right.</figcaption>
+<figcaption>Acknowledge every click</figcaption>
 <img src="/assets/acknowledge_actions_thumbnail.svg" width="400" alt="Two buttons: a yellow 'Submit' button labeled 'idle button', and a dashed-border orange 'Submitting…' button with a small rotating indicator labeled 'acknowledged + disabled'"/>
 </figure>
 

--- a/src/patterns/acknowledge_actions.md
+++ b/src/patterns/acknowledge_actions.md
@@ -5,6 +5,10 @@ tags: pattern
 thumbnail: /assets/acknowledge_actions_thumbnail.svg
 og_image: /assets/speed_patterns_og_image.jpg
 order: 7
+date: 2017-12-04
+authors:
+    - name: Sergey Chernyshev
+      url: https://www.sergeychernyshev.com/
 ---
 
 When a user clicks a button, taps a link, or submits a form, they expect immediate feedback. If the system takes longer than about 100ms to respond, an unacknowledged action becomes a usability problem — and a performance problem.

--- a/src/patterns/acknowledge_actions.md
+++ b/src/patterns/acknowledge_actions.md
@@ -29,19 +29,19 @@ Give the user visible feedback the instant their action begins, separate from th
 
 ### Common acknowledgments
 
-- **Disable the trigger.** A submitted button that immediately becomes disabled prevents double submission and signals "we got it."
-- **Change the label.** "Submit" → "Submitting…" or "Save" → "Saving…" tells the user exactly what is happening.
-- **Show a small inline indicator.** A subtle spinner _next to_ the action (not in place of the page content) confirms work is in progress.
-- **Pre-clear the destination area.** For navigation that will replace a content region, clear the old content immediately so the user sees the page begin to respond, even before the new content arrives.
-- **Move attention to the next state.** Modals can begin their open animation immediately, even if their content streams in.
+- **Disable the trigger.** A submitted button that immediately becomes disabled prevents double submission and signals "we got it"
+- **Change the label.** "Submit" → "Submitting…" or "Save" → "Saving…" tells the user exactly what is happening
+- **Show a small inline indicator.** A subtle spinner _next to_ the action (not in place of the page content) confirms work is in progress
+- **Pre-clear the destination area.** For navigation that will replace a content region, clear the old content immediately so the user sees the page begin to respond, even before the new content arrives
+- **Move attention to the next state.** Modals can begin their open animation immediately, even if their content streams in
 
 ## Guidelines
 
-- **Acknowledge in the first frame.** The acknowledgment must happen on the same paint as the input event — not after a network round-trip. If you wait for the server, you've already lost the moment.
-- **Acknowledge in place.** Show the feedback _on or next to_ the element the user interacted with, not in a distant corner of the page.
-- **Don't lie about progress.** Use indeterminate indicators when you don't know how long the operation will take; only show progress bars when you actually have progress information.
-- **Re-enable carefully.** Once the operation completes (success or error), restore the trigger to a usable state and tell the user what happened.
-- **Don't replace acknowledgment with a full-page spinner.** Spinners on top of working content are a heavy hammer — see [Don't Use Spinners](/patterns/dont_use_spinners/).
+- **Acknowledge in the first frame.** The acknowledgment must happen on the same paint as the input event — not after a network round-trip. If you wait for the server, you've already lost the moment
+- **Acknowledge in place.** Show the feedback _on or next to_ the element the user interacted with, not in a distant corner of the page
+- **Don't lie about progress.** Use indeterminate indicators when you don't know how long the operation will take; only show progress bars when you actually have progress information
+- **Re-enable carefully.** Once the operation completes (success or error), restore the trigger to a usable state and tell the user what happened
+- **Don't replace acknowledgment with a full-page spinner.** Spinners on top of working content are a heavy hammer — see [Don't Use Spinners](/patterns/dont_use_spinners/)
 
 ## Why This Works
 
@@ -49,9 +49,9 @@ The technical work behind the action hasn't gotten any faster, but the experienc
 
 ## Related Patterns
 
-- [Masking Slowness With Animation](/patterns/masking_slowness_with_animation/) — pairing acknowledgment with a transition to occupy the wait.
-- [Don't Use Spinners](/patterns/dont_use_spinners/) — preferred alternatives for longer waits.
-- [Skeletal Designs](/patterns/skeletal_designs/) — for acknowledging navigation that loads a whole new view.
+- [Masking Slowness With Animation](/patterns/masking_slowness_with_animation/) — pairing acknowledgment with a transition to occupy the wait
+- [Don't Use Spinners](/patterns/dont_use_spinners/) — preferred alternatives for longer waits
+- [Skeletal Designs](/patterns/skeletal_designs/) — for acknowledging navigation that loads a whole new view
 
 ## Technical Implementation
 

--- a/src/patterns/acknowledge_actions.md
+++ b/src/patterns/acknowledge_actions.md
@@ -25,6 +25,11 @@ The threshold matters: research on perceived responsiveness consistently puts ro
 
 ## Solution
 
+<figure>
+<figcaption>The same control on click: idle state on the left, immediately disabled with a "Submitting…" label and inline indicator on the right.</figcaption>
+<img src="/assets/acknowledge_actions_thumbnail.svg" width="400" alt="Two buttons: a yellow 'Submit' button labeled 'idle button', and a dashed-border orange 'Submitting…' button with a small rotating indicator labeled 'acknowledged + disabled'"/>
+</figure>
+
 Give the user visible feedback the instant their action begins, separate from the action's actual completion. The acknowledgment is a UI-only concern — it doesn't have to wait for the network.
 
 ### Common acknowledgments

--- a/src/patterns/acknowledge_actions.md
+++ b/src/patterns/acknowledge_actions.md
@@ -28,8 +28,8 @@ The threshold matters: research on perceived responsiveness consistently puts ro
 The same control on click: idle state on the left, immediately disabled with a "Submitting…" label and inline indicator on the right.
 
 <figure>
-<figcaption>Acknowledge every click</figcaption>
 <img src="/assets/acknowledge_actions_thumbnail.svg" width="400" alt="Two buttons: a yellow 'Submit' button labeled 'idle button', and a dashed-border orange 'Submitting…' button with a small rotating indicator labeled 'acknowledged + disabled'"/>
+<figcaption>Acknowledge every click</figcaption>
 </figure>
 
 Give the user visible feedback the instant their action begins, separate from the action's actual completion. The acknowledgment is a UI-only concern — it doesn't have to wait for the network.

--- a/src/patterns/acknowledge_actions.md
+++ b/src/patterns/acknowledge_actions.md
@@ -35,22 +35,6 @@ Give the user visible feedback the instant their action begins, separate from th
 - **Pre-clear the destination area.** For navigation that will replace a content region, clear the old content immediately so the user sees the page begin to respond, even before the new content arrives.
 - **Move attention to the next state.** Modals can begin their open animation immediately, even if their content streams in.
 
-### Example: a form submit button
-
-```html
-<button type="submit" id="submit-btn">Submit</button>
-```
-
-```js
-form.addEventListener("submit", () => {
-  const btn = document.getElementById("submit-btn");
-  btn.disabled = true;
-  btn.textContent = "Submitting…";
-});
-```
-
-This costs almost nothing to implement, and it makes the slow path feel intentional rather than broken.
-
 ## Guidelines
 
 - **Acknowledge in the first frame.** The acknowledgment must happen on the same paint as the input event — not after a network round-trip. If you wait for the server, you've already lost the moment.
@@ -68,3 +52,21 @@ The technical work behind the action hasn't gotten any faster, but the experienc
 - [Masking Slowness With Animation](/patterns/masking_slowness_with_animation/) — pairing acknowledgment with a transition to occupy the wait.
 - [Don't Use Spinners](/patterns/dont_use_spinners/) — preferred alternatives for longer waits.
 - [Skeletal Designs](/patterns/skeletal_designs/) — for acknowledging navigation that loads a whole new view.
+
+## Technical Implementation
+
+A minimal form submission acknowledgment is essentially two lines of code: disable the button and change its label as soon as the submit event fires.
+
+```html
+<button type="submit" id="submit-btn">Submit</button>
+```
+
+```js
+form.addEventListener("submit", () => {
+  const btn = document.getElementById("submit-btn");
+  btn.disabled = true;
+  btn.textContent = "Submitting…";
+});
+```
+
+This costs almost nothing to implement, and it makes the slow path feel intentional rather than broken. The same pattern applies to any control that initiates work — change the visual state in the same frame as the input event, not after the response returns.

--- a/src/patterns/acknowledge_actions.md
+++ b/src/patterns/acknowledge_actions.md
@@ -1,0 +1,70 @@
+---
+layout: article.njk
+title: Acknowledge Actions
+tags: pattern
+thumbnail: /assets/acknowledge_actions_thumbnail.svg
+og_image: /assets/speed_patterns_og_image.jpg
+order: 7
+---
+
+When a user clicks a button, taps a link, or submits a form, they expect immediate feedback. If the system takes longer than about 100ms to respond, an unacknowledged action becomes a usability problem — and a performance problem.
+
+<!-- excerpt -->
+
+## The Problem
+
+Without acknowledgment, the user is left to guess:
+
+- Did the click register? Was the tap on the wrong element?
+- Should I click again? (Often resulting in duplicate submissions.)
+- Is the page broken? (Often resulting in the user navigating away.)
+
+This isn't a hypothetical — duplicate form submissions are a classic symptom of missing acknowledgment, and most engineers have seen the resulting "duplicate order" tickets.
+
+The threshold matters: research on perceived responsiveness consistently puts roughly **100ms** as the upper bound for an action to feel instantaneous. Any longer, and the user notices the delay. Beyond about a second, the user starts to disengage entirely.
+
+## Solution
+
+Give the user visible feedback the instant their action begins, separate from the action's actual completion. The acknowledgment is a UI-only concern — it doesn't have to wait for the network.
+
+### Common acknowledgments
+
+- **Disable the trigger.** A submitted button that immediately becomes disabled prevents double submission and signals "we got it."
+- **Change the label.** "Submit" → "Submitting…" or "Save" → "Saving…" tells the user exactly what is happening.
+- **Show a small inline indicator.** A subtle spinner _next to_ the action (not in place of the page content) confirms work is in progress.
+- **Pre-clear the destination area.** For navigation that will replace a content region, clear the old content immediately so the user sees the page begin to respond, even before the new content arrives.
+- **Move attention to the next state.** Modals can begin their open animation immediately, even if their content streams in.
+
+### Example: a form submit button
+
+```html
+<button type="submit" id="submit-btn">Submit</button>
+```
+
+```js
+form.addEventListener("submit", () => {
+  const btn = document.getElementById("submit-btn");
+  btn.disabled = true;
+  btn.textContent = "Submitting…";
+});
+```
+
+This costs almost nothing to implement, and it makes the slow path feel intentional rather than broken.
+
+## Guidelines
+
+- **Acknowledge in the first frame.** The acknowledgment must happen on the same paint as the input event — not after a network round-trip. If you wait for the server, you've already lost the moment.
+- **Acknowledge in place.** Show the feedback _on or next to_ the element the user interacted with, not in a distant corner of the page.
+- **Don't lie about progress.** Use indeterminate indicators when you don't know how long the operation will take; only show progress bars when you actually have progress information.
+- **Re-enable carefully.** Once the operation completes (success or error), restore the trigger to a usable state and tell the user what happened.
+- **Don't replace acknowledgment with a full-page spinner.** Spinners on top of working content are a heavy hammer — see [Don't Use Spinners](/patterns/dont_use_spinners/).
+
+## Why This Works
+
+The technical work behind the action hasn't gotten any faster, but the experience has. The user knows the system is working on their behalf, can see exactly which action is in progress, and isn't tempted to retry. The site feels responsive even when the network isn't.
+
+## Related Patterns
+
+- [Masking Slowness With Animation](/patterns/masking_slowness_with_animation/) — pairing acknowledgment with a transition to occupy the wait.
+- [Don't Use Spinners](/patterns/dont_use_spinners/) — preferred alternatives for longer waits.
+- [Skeletal Designs](/patterns/skeletal_designs/) — for acknowledging navigation that loads a whole new view.

--- a/src/patterns/acknowledge_actions.md
+++ b/src/patterns/acknowledge_actions.md
@@ -19,7 +19,7 @@ Without acknowledgment, the user is left to guess:
 - Should I click again? (Often resulting in duplicate submissions.)
 - Is the page broken? (Often resulting in the user navigating away.)
 
-This isn't a hypothetical — duplicate form submissions are a classic symptom of missing acknowledgment, and most engineers have seen the resulting "duplicate order" tickets.
+This isn't a hypothetical — duplicate form submissions are a classic symptom of missing acknowledgment, and most engineers have seen the resulting "duplicate order" tickets. The same frustration shows up as **rage clicks** — repeated, accelerating taps on the same element that real-user monitoring tools flag as a user-frustration signal. A button that gives no feedback for a couple of seconds is the most reliable way to manufacture them.
 
 The threshold matters: research on perceived responsiveness consistently puts roughly **100ms** as the upper bound for an action to feel instantaneous. Any longer, and the user notices the delay. Beyond about a second, the user starts to disengage entirely.
 

--- a/src/patterns/acknowledge_actions.md
+++ b/src/patterns/acknowledge_actions.md
@@ -5,6 +5,7 @@ tags: pattern
 thumbnail: /assets/acknowledge_actions_thumbnail.svg
 og_image: /assets/speed_patterns_og_image.jpg
 order: 7
+ai_assisted: true
 date: 2017-12-04
 authors:
     - name: Sergey Chernyshev

--- a/src/patterns/acknowledge_actions.md
+++ b/src/patterns/acknowledge_actions.md
@@ -36,11 +36,10 @@ Give the user visible feedback the instant their action begins, separate from th
 
 ### Common acknowledgments
 
-- **Disable the trigger.** A submitted button that immediately becomes disabled prevents double submission and signals "we got it"
-- **Change the label.** "Submit" → "Submitting…" or "Save" → "Saving…" tells the user exactly what is happening
-- **Show a small inline indicator.** A subtle spinner _next to_ the action (not in place of the page content) confirms work is in progress
-- **Pre-clear the destination area.** For navigation that will replace a content region, clear the old content immediately so the user sees the page begin to respond, even before the new content arrives
-- **Move attention to the next state.** Modals can begin their open animation immediately, even if their content streams in
+- **Disable the trigger:** A submitted button that immediately becomes disabled prevents double submission and signals "we got it"
+- **Change the label:** "Submit" → "Submitting…" or "Save" → "Saving…" tells the user exactly what is happening
+- **Pre-clear the destination area:** For navigation that will replace a content region, clear the old content immediately so the user sees the page begin to respond, even before the new content arrives
+- **Move attention to the next state:** Modals can begin their open animation immediately, even if their content streams in
 
 ## Guidelines
 


### PR DESCRIPTION
## Summary
- Adds a new pattern article on giving users immediate visual feedback for any action that takes longer than ~100ms — disabling triggers, changing labels, inline indicators, and pre-clearing destination regions.
- Includes a simple SVG thumbnail and reuses the site-wide OG image.

Closes #4

## Test plan
- [ ] Run \`npm run start\` and verify the article renders at \`/patterns/acknowledge_actions/\`
- [ ] Confirm the new pattern appears in the homepage list with thumbnail
- [ ] Confirm the new pattern shows up in the side nav

🤖 Generated with [Claude Code](https://claude.com/claude-code)