### PR TITLE
Add Use Styles Instead Of Images pattern

### DIFF
--- a/src/assets/styles_not_images_thumbnail.svg
+++ b/src/assets/styles_not_images_thumbnail.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 50 400 240" width="400" height="240">
   <rect width="400" height="300" fill="#fff"/>
   <g transform="translate(35,70)">
-    <rect x="0" y="0" width="140" height="200" fill="#ffa400" stroke="#000" stroke-width="3"/>
+    <rect x="0" y="0" width="140" height="200" fill="#fff" stroke="#000" stroke-width="3"/>
     <g transform="translate(20,28)">
       <rect x="0" y="0" width="100" height="56" fill="#fff" stroke="#000" stroke-width="2"/>
       <g fill="#000">
@@ -33,7 +33,7 @@
   </g>
   <polygon points="200,160 215,165 200,170" fill="#000"/>
   <g transform="translate(225,70)">
-    <rect x="0" y="0" width="140" height="200" fill="#fd0" stroke="#000" stroke-width="3"/>
+    <rect x="0" y="0" width="140" height="200" fill="#fff" stroke="#000" stroke-width="3"/>
     <rect x="20" y="28" width="100" height="56" rx="14" fill="#0085f1" stroke="#000" stroke-width="2"/>
     <text x="70" y="120" text-anchor="middle" font-family="Arial, sans-serif" font-size="11" fill="#000" font-weight="bold">CSS: ~120 B</text>
     <text x="70" y="142" text-anchor="middle" font-family="Arial, sans-serif" font-size="11" fill="#000">crisp at any DPI</text>

--- a/src/assets/styles_not_images_thumbnail.svg
+++ b/src/assets/styles_not_images_thumbnail.svg
@@ -1,43 +1,43 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 300" width="400" height="300">
-  <rect width="400" height="300" fill="#fff4de"/>
-  <text x="200" y="38" text-anchor="middle" font-family="sans-serif" font-size="20" fill="#5a4a2e" font-weight="bold">Pixels vs. CSS</text>
-  <g transform="translate(40,80)">
-    <rect x="0" y="0" width="140" height="180" rx="6" fill="#fff8eb" stroke="#a98c5a" stroke-width="2"/>
-    <g transform="translate(20,30)">
-      <rect x="0" y="0" width="100" height="60" fill="none" stroke="#a98c5a" stroke-width="1" stroke-dasharray="3 3"/>
-      <g fill="#a98c5a">
-        <rect x="2" y="2" width="6" height="6"/>
-        <rect x="14" y="6" width="6" height="6"/>
-        <rect x="28" y="2" width="6" height="6"/>
-        <rect x="42" y="10" width="6" height="6"/>
-        <rect x="56" y="4" width="6" height="6"/>
-        <rect x="70" y="14" width="6" height="6"/>
-        <rect x="84" y="6" width="6" height="6"/>
-        <rect x="6" y="22" width="6" height="6"/>
-        <rect x="22" y="30" width="6" height="6"/>
-        <rect x="38" y="24" width="6" height="6"/>
-        <rect x="54" y="34" width="6" height="6"/>
-        <rect x="68" y="26" width="6" height="6"/>
-        <rect x="80" y="38" width="6" height="6"/>
-        <rect x="10" y="48" width="6" height="6"/>
-        <rect x="34" y="44" width="6" height="6"/>
-        <rect x="60" y="50" width="6" height="6"/>
-        <rect x="78" y="46" width="6" height="6"/>
+  <rect width="400" height="300" fill="#fff"/>
+  <text x="200" y="36" text-anchor="middle" font-family="Arial, sans-serif" font-size="20" fill="#000" font-weight="bold">Pixels vs. CSS</text>
+  <g transform="translate(35,70)">
+    <rect x="0" y="0" width="140" height="200" fill="#ffa400" stroke="#000" stroke-width="3"/>
+    <g transform="translate(20,28)">
+      <rect x="0" y="0" width="100" height="56" fill="#fff" stroke="#000" stroke-width="2"/>
+      <g fill="#000">
+        <rect x="4" y="4" width="6" height="6"/>
+        <rect x="16" y="6" width="6" height="6"/>
+        <rect x="30" y="2" width="6" height="6"/>
+        <rect x="44" y="8" width="6" height="6"/>
+        <rect x="58" y="4" width="6" height="6"/>
+        <rect x="72" y="10" width="6" height="6"/>
+        <rect x="86" y="6" width="6" height="6"/>
+        <rect x="6" y="20" width="6" height="6"/>
+        <rect x="24" y="26" width="6" height="6"/>
+        <rect x="40" y="22" width="6" height="6"/>
+        <rect x="56" y="30" width="6" height="6"/>
+        <rect x="70" y="24" width="6" height="6"/>
+        <rect x="82" y="34" width="6" height="6"/>
+        <rect x="10" y="42" width="6" height="6"/>
+        <rect x="36" y="40" width="6" height="6"/>
+        <rect x="62" y="46" width="6" height="6"/>
+        <rect x="80" y="42" width="6" height="6"/>
       </g>
     </g>
-    <text x="70" y="120" text-anchor="middle" font-family="sans-serif" font-size="11" fill="#5a4a2e">image: 142 KB</text>
-    <text x="70" y="140" text-anchor="middle" font-family="sans-serif" font-size="11" fill="#5a4a2e">blurry on retina</text>
-    <text x="70" y="160" text-anchor="middle" font-family="sans-serif" font-size="11" fill="#5a4a2e">slow to render</text>
+    <text x="70" y="120" text-anchor="middle" font-family="Arial, sans-serif" font-size="11" fill="#000" font-weight="bold">image: 142 KB</text>
+    <text x="70" y="142" text-anchor="middle" font-family="Arial, sans-serif" font-size="11" fill="#000">blurry on retina</text>
+    <text x="70" y="160" text-anchor="middle" font-family="Arial, sans-serif" font-size="11" fill="#000">slow to render</text>
   </g>
-  <g stroke="#a98c5a" stroke-width="3" fill="none" stroke-linecap="round">
-    <path d="M195 170 L235 170" />
-    <polygon points="235,165 247,170 235,175" fill="#a98c5a"/>
+  <g stroke="#000" stroke-width="3" fill="none" stroke-linecap="round">
+    <path d="M185 165 L215 165"/>
   </g>
-  <g transform="translate(255,80)">
-    <rect x="0" y="0" width="140" height="180" rx="6" fill="#fff8eb" stroke="#a98c5a" stroke-width="2"/>
-    <rect x="20" y="30" width="100" height="60" rx="14" fill="#a98c5a" filter="url(#shadow)"/>
-    <text x="70" y="120" text-anchor="middle" font-family="sans-serif" font-size="11" fill="#5a4a2e">CSS: ~120 B</text>
-    <text x="70" y="140" text-anchor="middle" font-family="sans-serif" font-size="11" fill="#5a4a2e">crisp at any DPI</text>
-    <text x="70" y="160" text-anchor="middle" font-family="sans-serif" font-size="11" fill="#5a4a2e">animatable</text>
+  <polygon points="215,160 230,165 215,170" fill="#000"/>
+  <g transform="translate(225,70)">
+    <rect x="0" y="0" width="140" height="200" fill="#fd0" stroke="#000" stroke-width="3"/>
+    <rect x="20" y="28" width="100" height="56" rx="14" fill="#0085f1" stroke="#000" stroke-width="2"/>
+    <text x="70" y="120" text-anchor="middle" font-family="Arial, sans-serif" font-size="11" fill="#000" font-weight="bold">CSS: ~120 B</text>
+    <text x="70" y="142" text-anchor="middle" font-family="Arial, sans-serif" font-size="11" fill="#000">crisp at any DPI</text>
+    <text x="70" y="160" text-anchor="middle" font-family="Arial, sans-serif" font-size="11" fill="#000">animatable</text>
   </g>
 </svg>

--- a/src/assets/styles_not_images_thumbnail.svg
+++ b/src/assets/styles_not_images_thumbnail.svg
@@ -1,0 +1,43 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 300" width="400" height="300">
+  <rect width="400" height="300" fill="#fff4de"/>
+  <text x="200" y="38" text-anchor="middle" font-family="sans-serif" font-size="20" fill="#5a4a2e" font-weight="bold">Pixels vs. CSS</text>
+  <g transform="translate(40,80)">
+    <rect x="0" y="0" width="140" height="180" rx="6" fill="#fff8eb" stroke="#a98c5a" stroke-width="2"/>
+    <g transform="translate(20,30)">
+      <rect x="0" y="0" width="100" height="60" fill="none" stroke="#a98c5a" stroke-width="1" stroke-dasharray="3 3"/>
+      <g fill="#a98c5a">
+        <rect x="2" y="2" width="6" height="6"/>
+        <rect x="14" y="6" width="6" height="6"/>
+        <rect x="28" y="2" width="6" height="6"/>
+        <rect x="42" y="10" width="6" height="6"/>
+        <rect x="56" y="4" width="6" height="6"/>
+        <rect x="70" y="14" width="6" height="6"/>
+        <rect x="84" y="6" width="6" height="6"/>
+        <rect x="6" y="22" width="6" height="6"/>
+        <rect x="22" y="30" width="6" height="6"/>
+        <rect x="38" y="24" width="6" height="6"/>
+        <rect x="54" y="34" width="6" height="6"/>
+        <rect x="68" y="26" width="6" height="6"/>
+        <rect x="80" y="38" width="6" height="6"/>
+        <rect x="10" y="48" width="6" height="6"/>
+        <rect x="34" y="44" width="6" height="6"/>
+        <rect x="60" y="50" width="6" height="6"/>
+        <rect x="78" y="46" width="6" height="6"/>
+      </g>
+    </g>
+    <text x="70" y="120" text-anchor="middle" font-family="sans-serif" font-size="11" fill="#5a4a2e">image: 142 KB</text>
+    <text x="70" y="140" text-anchor="middle" font-family="sans-serif" font-size="11" fill="#5a4a2e">blurry on retina</text>
+    <text x="70" y="160" text-anchor="middle" font-family="sans-serif" font-size="11" fill="#5a4a2e">slow to render</text>
+  </g>
+  <g stroke="#a98c5a" stroke-width="3" fill="none" stroke-linecap="round">
+    <path d="M195 170 L235 170" />
+    <polygon points="235,165 247,170 235,175" fill="#a98c5a"/>
+  </g>
+  <g transform="translate(255,80)">
+    <rect x="0" y="0" width="140" height="180" rx="6" fill="#fff8eb" stroke="#a98c5a" stroke-width="2"/>
+    <rect x="20" y="30" width="100" height="60" rx="14" fill="#a98c5a" filter="url(#shadow)"/>
+    <text x="70" y="120" text-anchor="middle" font-family="sans-serif" font-size="11" fill="#5a4a2e">CSS: ~120 B</text>
+    <text x="70" y="140" text-anchor="middle" font-family="sans-serif" font-size="11" fill="#5a4a2e">crisp at any DPI</text>
+    <text x="70" y="160" text-anchor="middle" font-family="sans-serif" font-size="11" fill="#5a4a2e">animatable</text>
+  </g>
+</svg>

--- a/src/assets/styles_not_images_thumbnail.svg
+++ b/src/assets/styles_not_images_thumbnail.svg
@@ -1,6 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 300" width="400" height="300">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 50 400 240" width="400" height="240">
   <rect width="400" height="300" fill="#fff"/>
-  <text x="200" y="36" text-anchor="middle" font-family="Arial, sans-serif" font-size="20" fill="#000" font-weight="bold">Pixels vs. CSS</text>
   <g transform="translate(35,70)">
     <rect x="0" y="0" width="140" height="200" fill="#ffa400" stroke="#000" stroke-width="3"/>
     <g transform="translate(20,28)">

--- a/src/assets/styles_not_images_thumbnail.svg
+++ b/src/assets/styles_not_images_thumbnail.svg
@@ -29,9 +29,9 @@
     <text x="70" y="160" text-anchor="middle" font-family="Arial, sans-serif" font-size="11" fill="#000">slow to render</text>
   </g>
   <g stroke="#000" stroke-width="3" fill="none" stroke-linecap="round">
-    <path d="M185 165 L215 165"/>
+    <path d="M185 165 L200 165"/>
   </g>
-  <polygon points="215,160 230,165 215,170" fill="#000"/>
+  <polygon points="200,160 215,165 200,170" fill="#000"/>
   <g transform="translate(225,70)">
     <rect x="0" y="0" width="140" height="200" fill="#fd0" stroke="#000" stroke-width="3"/>
     <rect x="20" y="28" width="100" height="56" rx="14" fill="#0085f1" stroke="#000" stroke-width="2"/>

--- a/src/patterns/use_styles_instead_of_images.md
+++ b/src/patterns/use_styles_instead_of_images.md
@@ -5,6 +5,7 @@ tags: pattern
 thumbnail: /assets/styles_not_images_thumbnail.svg
 og_image: /assets/speed_patterns_og_image.jpg
 order: 8
+ai_assisted: true
 date: 2017-12-05
 authors:
     - name: Sergey Chernyshev

--- a/src/patterns/use_styles_instead_of_images.md
+++ b/src/patterns/use_styles_instead_of_images.md
@@ -1,0 +1,94 @@
+---
+layout: article.njk
+title: Use Styles Instead Of Images
+tags: pattern
+thumbnail: /assets/styles_not_images_thumbnail.svg
+og_image: /assets/speed_patterns_og_image.jpg
+order: 8
+---
+
+Visual effects that originate in design tools — drop shadows, gradients, rounded corners, decorative borders, even small icons — are often shipped to the browser as raster images. They didn't have to be. CSS can express most of those effects directly in markup, at a tiny fraction of the byte cost and with no loss of fidelity.
+
+<!-- excerpt -->
+
+## The Problem
+
+A typical handoff path looks like this: the designer builds a mockup in Figma or Photoshop, exports the visual elements as PNG or JPEG, and the developer drops the exports into the page. The result _looks_ right, but it's expensive:
+
+- A drop shadow exported as a PNG can be 40–100 KB. The same shadow in CSS is a few bytes.
+- A button rendered as an image is one network request, one rasterization step, and one fixed resolution. The same button in CSS scales to any DPI for free.
+- A "hero" image with overlaid text saves time at design handoff but binds the text into the pixels — making it un-translatable, un-selectable, and bad for SEO.
+
+Every image is a network round-trip, a decode step on the user's CPU, and a layout consideration. Avoiding the round-trip entirely is almost always cheaper.
+
+## Solution
+
+Make CSS the default for any visual element that isn't fundamentally photographic. Reach for an image only when the content is a real photo or a complex illustration that CSS truly can't express.
+
+### What CSS handles well
+
+- **Shadows** — `box-shadow`, `text-shadow`, `filter: drop-shadow()`
+- **Rounded corners** — `border-radius` (including elliptical and per-corner values)
+- **Gradients** — linear, radial, conic, with stops and color interpolation
+- **Borders and dividers** — solid, dashed, dotted, double, with custom widths and colors
+- **Backgrounds and overlays** — multiple backgrounds, blend modes, masks
+- **Icons** — most simple icons are better as inline SVG (resolution-independent and styleable) than as PNG sprites
+- **Animations and transitions** — hover effects, fades, slides, pulses
+- **Typography effects** — letterspacing, alternating colors, decorative underlines
+
+If your designer says "I want this corner rounded with a soft shadow and a thin border" — that's three lines of CSS and zero images.
+
+### Anti-pattern: the mixed hero
+
+A common offender is a hero banner that combines a photographic image with overlaid text. Designers often deliver this as a single rendered image — and the result is bad on both axes:
+
+- **PNG** preserves the text edges crisply but bloats the photographic part.
+- **JPEG** compresses the photo well but introduces visible artifacts around the text.
+
+The right answer is to split the layers:
+
+```html
+<section class="hero">
+  <img src="/assets/hero-photo.jpg" alt="" class="hero__photo" />
+  <div class="hero__copy">
+    <h1>Crisp, real text</h1>
+    <p>Selectable, translatable, accessible.</p>
+  </div>
+</section>
+```
+
+```css
+.hero { position: relative; }
+.hero__photo { width: 100%; height: 100%; object-fit: cover; }
+.hero__copy {
+  position: absolute; inset: 0;
+  display: grid; place-content: center;
+  color: white;
+  text-shadow: 0 2px 6px rgba(0, 0, 0, 0.5);
+}
+```
+
+The photo can be aggressively compressed (it's only being judged as a photo). The text stays crisp, accessible, responsive, and editable without shipping a new image.
+
+## Why This Works
+
+CSS rules are part of the stylesheet — already cached, already parsed, already applied to many elements. Replacing an image with CSS:
+
+- Eliminates a network request (or several, if multiple sizes were being served).
+- Eliminates the decode and rasterization cost.
+- Lets the browser scale the visual to any device pixel ratio without blurriness.
+- Allows hover, focus and animation states without preloading additional image variants.
+- Keeps text editable and indexable.
+
+## Guidelines
+
+- **Default to CSS.** Make "could this be done in CSS?" a routine question during design review, not an afterthought during optimization.
+- **Use SVG for icons and simple illustrations.** Inline SVG can be styled with CSS and animated, and stays sharp at every resolution.
+- **Reserve raster images for actual photographs** — and use modern formats (`AVIF`, `WebP`) with proper `srcset` and `sizes` for responsiveness.
+- **Don't ship text as pixels.** Text is content; it belongs in HTML.
+- **Tooling helps.** Modern CSS supports complex effects that were once only achievable with images — re-investigate the boundary periodically.
+
+## Related Patterns
+
+- [Fast Start](/patterns/fast_start/) — fewer bytes and fewer requests directly improve First Contentful Paint.
+- [Immutable Layout](/patterns/immutable_layout/) — CSS-rendered visuals know their dimensions immediately, so they don't shift.

--- a/src/patterns/use_styles_instead_of_images.md
+++ b/src/patterns/use_styles_instead_of_images.md
@@ -87,11 +87,19 @@ The mixed-hero anti-pattern is fixed by separating the photographic layer from t
 ```
 
 ```css
-.hero { position: relative; }
-.hero__photo { width: 100%; height: 100%; object-fit: cover; }
+.hero {
+  position: relative;
+}
+.hero__photo {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
 .hero__copy {
-  position: absolute; inset: 0;
-  display: grid; place-content: center;
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-content: center;
   color: white;
   text-shadow: 0 2px 6px rgba(0, 0, 0, 0.5);
 }

--- a/src/patterns/use_styles_instead_of_images.md
+++ b/src/patterns/use_styles_instead_of_images.md
@@ -5,6 +5,10 @@ tags: pattern
 thumbnail: /assets/styles_not_images_thumbnail.svg
 og_image: /assets/speed_patterns_og_image.jpg
 order: 8
+date: 2017-12-05
+authors:
+    - name: Sergey Chernyshev
+      url: https://www.sergeychernyshev.com/
 ---
 
 Visual effects that originate in design tools — drop shadows, gradients, rounded corners, decorative borders, even small icons — are often shipped to the browser as raster images. They didn't have to be. CSS can express most of those effects directly in markup, at a tiny fraction of the byte cost and with no loss of fidelity.

--- a/src/patterns/use_styles_instead_of_images.md
+++ b/src/patterns/use_styles_instead_of_images.md
@@ -15,9 +15,9 @@ Visual effects that originate in design tools — drop shadows, gradients, round
 
 A typical handoff path looks like this: the designer builds a mockup in Figma or Photoshop, exports the visual elements as PNG or JPEG, and the developer drops the exports into the page. The result _looks_ right, but it's expensive:
 
-- A drop shadow exported as a PNG can be 40–100 KB. The same shadow in CSS is a few bytes.
-- A button rendered as an image is one network request, one rasterization step, and one fixed resolution. The same button in CSS scales to any DPI for free.
-- A "hero" image with overlaid text saves time at design handoff but binds the text into the pixels — making it un-translatable, un-selectable, and bad for SEO.
+- A drop shadow exported as a PNG can be 40–100 KB. The same shadow in CSS is a few bytes
+- A button rendered as an image is one network request, one rasterization step, and one fixed resolution. The same button in CSS scales to any DPI for free
+- A "hero" image with overlaid text saves time at design handoff but binds the text into the pixels — making it un-translatable, un-selectable, and bad for SEO
 
 Every image is a network round-trip, a decode step on the user's CPU, and a layout consideration. Avoiding the round-trip entirely is almost always cheaper.
 
@@ -42,8 +42,8 @@ If your designer says "I want this corner rounded with a soft shadow and a thin 
 
 A common offender is a hero banner that combines a photographic image with overlaid text. Designers often deliver this as a single rendered image — and the result is bad on both axes:
 
-- **PNG** preserves the text edges crisply but bloats the photographic part.
-- **JPEG** compresses the photo well but introduces visible artifacts around the text.
+- **PNG** preserves the text edges crisply but bloats the photographic part
+- **JPEG** compresses the photo well but introduces visible artifacts around the text
 
 The right answer is to split the layers: keep the photo as a compressed image and render the text as real HTML positioned over it. The photo can be aggressively compressed (it's only being judged as a photo). The text stays crisp, accessible, responsive, and editable without shipping a new image.
 
@@ -51,24 +51,24 @@ The right answer is to split the layers: keep the photo as a compressed image an
 
 CSS rules are part of the stylesheet — already cached, already parsed, already applied to many elements. Replacing an image with CSS:
 
-- Eliminates a network request (or several, if multiple sizes were being served).
-- Eliminates the decode and rasterization cost.
-- Lets the browser scale the visual to any device pixel ratio without blurriness.
-- Allows hover, focus and animation states without preloading additional image variants.
-- Keeps text editable and indexable.
+- Eliminates a network request (or several, if multiple sizes were being served)
+- Eliminates the decode and rasterization cost
+- Lets the browser scale the visual to any device pixel ratio without blurriness
+- Allows hover, focus and animation states without preloading additional image variants
+- Keeps text editable and indexable
 
 ## Guidelines
 
-- **Default to CSS.** Make "could this be done in CSS?" a routine question during design review, not an afterthought during optimization.
-- **Use SVG for icons and simple illustrations.** Inline SVG can be styled with CSS and animated, and stays sharp at every resolution.
-- **Reserve raster images for actual photographs** — and use modern formats (`AVIF`, `WebP`) with proper `srcset` and `sizes` for responsiveness.
-- **Don't ship text as pixels.** Text is content; it belongs in HTML.
-- **Tooling helps.** Modern CSS supports complex effects that were once only achievable with images — re-investigate the boundary periodically.
+- **Default to CSS.** Make "could this be done in CSS?" a routine question during design review, not an afterthought during optimization
+- **Use SVG for icons and simple illustrations.** Inline SVG can be styled with CSS and animated, and stays sharp at every resolution
+- **Reserve raster images for actual photographs** — and use modern formats (`AVIF`, `WebP`) with proper `srcset` and `sizes` for responsiveness
+- **Don't ship text as pixels.** Text is content; it belongs in HTML
+- **Tooling helps.** Modern CSS supports complex effects that were once only achievable with images — re-investigate the boundary periodically
 
 ## Related Patterns
 
-- [Fast Start](/patterns/fast_start/) — fewer bytes and fewer requests directly improve First Contentful Paint.
-- [Immutable Layout](/patterns/immutable_layout/) — CSS-rendered visuals know their dimensions immediately, so they don't shift.
+- [Fast Start](/patterns/fast_start/) — fewer bytes and fewer requests directly improve First Contentful Paint
+- [Immutable Layout](/patterns/immutable_layout/) — CSS-rendered visuals know their dimensions immediately, so they don't shift
 
 ## Technical Implementation
 

--- a/src/patterns/use_styles_instead_of_images.md
+++ b/src/patterns/use_styles_instead_of_images.md
@@ -45,30 +45,7 @@ A common offender is a hero banner that combines a photographic image with overl
 - **PNG** preserves the text edges crisply but bloats the photographic part.
 - **JPEG** compresses the photo well but introduces visible artifacts around the text.
 
-The right answer is to split the layers:
-
-```html
-<section class="hero">
-  <img src="/assets/hero-photo.jpg" alt="" class="hero__photo" />
-  <div class="hero__copy">
-    <h1>Crisp, real text</h1>
-    <p>Selectable, translatable, accessible.</p>
-  </div>
-</section>
-```
-
-```css
-.hero { position: relative; }
-.hero__photo { width: 100%; height: 100%; object-fit: cover; }
-.hero__copy {
-  position: absolute; inset: 0;
-  display: grid; place-content: center;
-  color: white;
-  text-shadow: 0 2px 6px rgba(0, 0, 0, 0.5);
-}
-```
-
-The photo can be aggressively compressed (it's only being judged as a photo). The text stays crisp, accessible, responsive, and editable without shipping a new image.
+The right answer is to split the layers: keep the photo as a compressed image and render the text as real HTML positioned over it. The photo can be aggressively compressed (it's only being judged as a photo). The text stays crisp, accessible, responsive, and editable without shipping a new image.
 
 ## Why This Works
 
@@ -92,3 +69,36 @@ CSS rules are part of the stylesheet — already cached, already parsed, already
 
 - [Fast Start](/patterns/fast_start/) — fewer bytes and fewer requests directly improve First Contentful Paint.
 - [Immutable Layout](/patterns/immutable_layout/) — CSS-rendered visuals know their dimensions immediately, so they don't shift.
+
+## Technical Implementation
+
+### Splitting the mixed hero
+
+The mixed-hero anti-pattern is fixed by separating the photographic layer from the typographic one:
+
+```html
+<section class="hero">
+  <img src="/assets/hero-photo.jpg" alt="" class="hero__photo" />
+  <div class="hero__copy">
+    <h1>Crisp, real text</h1>
+    <p>Selectable, translatable, accessible.</p>
+  </div>
+</section>
+```
+
+```css
+.hero { position: relative; }
+.hero__photo { width: 100%; height: 100%; object-fit: cover; }
+.hero__copy {
+  position: absolute; inset: 0;
+  display: grid; place-content: center;
+  color: white;
+  text-shadow: 0 2px 6px rgba(0, 0, 0, 0.5);
+}
+```
+
+Each layer is now optimized for its own job: the JPEG can compress freely, and the text remains crisp, indexable and translatable.
+
+### CSS instead of decorative images
+
+Most decorative effects that once required images are direct CSS now: `box-shadow`, `border-radius`, `linear-gradient()`, `radial-gradient()`, `conic-gradient()`, `backdrop-filter`, `mask-image` and the `filter` family cover almost all of what design tools export. When in doubt, prototype the effect in CSS first; only fall back to a raster export if the browser truly can't reproduce it.

--- a/src/patterns/use_styles_instead_of_images.md
+++ b/src/patterns/use_styles_instead_of_images.md
@@ -24,8 +24,8 @@ Every image is a network round-trip, a decode step on the user's CPU, and a layo
 The same visual element shipped two ways: as a 142KB raster image, or as ~120 bytes of CSS. The CSS version is also crisp at any DPI and animatable.
 
 <figure>
-<figcaption>Pixels vs. CSS</figcaption>
 <img src="/assets/styles_not_images_thumbnail.svg" width="400" alt="Side-by-side comparison: a pixelated raster image labeled '142 KB, blurry on retina, slow to render' next to a smooth rounded rectangle labeled 'CSS: ~120 B, crisp at any DPI, animatable'"/>
+<figcaption>Pixels vs. CSS</figcaption>
 </figure>
 
 ## Solution

--- a/src/patterns/use_styles_instead_of_images.md
+++ b/src/patterns/use_styles_instead_of_images.md
@@ -24,7 +24,7 @@ Every image is a network round-trip, a decode step on the user's CPU, and a layo
 The same visual element shipped two ways: as a 142KB raster image, or as ~120 bytes of CSS. The CSS version is also crisp at any DPI and animatable.
 
 <figure>
-<img src="/assets/styles_not_images_thumbnail.svg" width="400" alt="Side-by-side comparison: a pixelated raster image labeled '142 KB, blurry on retina, slow to render' next to a smooth rounded rectangle labeled 'CSS: ~120 B, crisp at any DPI, animatable'"/>
+<img src="/assets/styles_not_images_thumbnail.svg" width="460" alt="Side-by-side comparison: a pixelated raster image labeled '142 KB, blurry on retina, slow to render' next to a smooth rounded rectangle labeled 'CSS: ~120 B, crisp at any DPI, animatable'"/>
 <figcaption>Pixels vs. CSS</figcaption>
 </figure>
 

--- a/src/patterns/use_styles_instead_of_images.md
+++ b/src/patterns/use_styles_instead_of_images.md
@@ -21,8 +21,10 @@ A typical handoff path looks like this: the designer builds a mockup in Figma or
 
 Every image is a network round-trip, a decode step on the user's CPU, and a layout consideration. Avoiding the round-trip entirely is almost always cheaper.
 
+The same visual element shipped two ways: as a 142KB raster image, or as ~120 bytes of CSS. The CSS version is also crisp at any DPI and animatable.
+
 <figure>
-<figcaption>The same visual element shipped two ways: as a 142KB raster image, or as ~120 bytes of CSS. The CSS version is also crisp at any DPI and animatable.</figcaption>
+<figcaption>Pixels vs. CSS</figcaption>
 <img src="/assets/styles_not_images_thumbnail.svg" width="400" alt="Side-by-side comparison: a pixelated raster image labeled '142 KB, blurry on retina, slow to render' next to a smooth rounded rectangle labeled 'CSS: ~120 B, crisp at any DPI, animatable'"/>
 </figure>
 

--- a/src/patterns/use_styles_instead_of_images.md
+++ b/src/patterns/use_styles_instead_of_images.md
@@ -21,6 +21,11 @@ A typical handoff path looks like this: the designer builds a mockup in Figma or
 
 Every image is a network round-trip, a decode step on the user's CPU, and a layout consideration. Avoiding the round-trip entirely is almost always cheaper.
 
+<figure>
+<figcaption>The same visual element shipped two ways: as a 142KB raster image, or as ~120 bytes of CSS. The CSS version is also crisp at any DPI and animatable.</figcaption>
+<img src="/assets/styles_not_images_thumbnail.svg" width="400" alt="Side-by-side comparison: a pixelated raster image labeled '142 KB, blurry on retina, slow to render' next to a smooth rounded rectangle labeled 'CSS: ~120 B, crisp at any DPI, animatable'"/>
+</figure>
+
 ## Solution
 
 Make CSS the default for any visual element that isn't fundamentally photographic. Reach for an image only when the content is a real photo or a complex illustration that CSS truly can't express.


### PR DESCRIPTION
## Summary
- Adds a new pattern article on preferring CSS for shadows, gradients, rounded corners, borders and icons; covers the mixed-hero anti-pattern and how to split image + text layers.
- Includes a simple SVG thumbnail and reuses the site-wide OG image.

Closes #5

## Test plan
- [ ] Run \`npm run start\` and verify the article renders at \`/patterns/use_styles_instead_of_images/\`
- [ ] Confirm the new pattern appears in the homepage list with thumbnail
- [ ] Confirm the new pattern shows up in the side nav

🤖 Generated with [Claude Code](https://claude.com/claude-code)