### PR TITLE
Add See and Do pattern

### DIFF
--- a/src/assets/see_and_do_thumbnail.svg
+++ b/src/assets/see_and_do_thumbnail.svg
@@ -1,6 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 300" width="400" height="300">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 50 400 250" width="400" height="250">
   <rect width="400" height="300" fill="#fff"/>
-  <text x="200" y="34" text-anchor="middle" font-family="Arial, sans-serif" font-size="20" fill="#000" font-weight="bold">Visible should mean usable</text>
   <g transform="translate(40,60)">
     <rect x="0" y="0" width="320" height="68" fill="#fff" stroke="#000" stroke-width="2"/>
     <text x="10" y="18" font-family="Arial, sans-serif" font-size="12" fill="#000" font-weight="bold">Page paint timeline</text>

--- a/src/assets/see_and_do_thumbnail.svg
+++ b/src/assets/see_and_do_thumbnail.svg
@@ -1,6 +1,27 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 50 400 250" width="400" height="250">
   <rect width="400" height="300" fill="#fff"/>
   <g transform="translate(40,60)">
+    <circle cx="40" cy="40" r="32" fill="#fd0" stroke="#000" stroke-width="3"/>
+    <circle cx="40" cy="40" r="12" fill="#000"/>
+    <text x="40" y="94" text-anchor="middle" font-family="Arial, sans-serif" font-size="13" fill="#000" font-weight="bold">SEE</text>
+    <text x="40" y="110" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#000">page is painted</text>
+  </g>
+  <g stroke="#0085f1" stroke-width="3" fill="none" stroke-linecap="round">
+    <path d="M85 100 L165 100"/>
+  </g>
+  <polygon points="165,95 178,100 165,105" fill="#0085f1"/>
+  <g transform="translate(180,70)">
+    <rect x="0" y="10" width="120" height="56" fill="#ffa400" stroke="#000" stroke-width="3"/>
+    <text x="60" y="44" text-anchor="middle" font-family="Arial, sans-serif" font-size="16" fill="#000" font-weight="bold">Click me</text>
+    <text x="60" y="84" text-anchor="middle" font-family="Arial, sans-serif" font-size="13" fill="#000" font-weight="bold">DO</text>
+    <text x="60" y="100" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#000">page should respond</text>
+  </g>
+  <g transform="translate(310,70)">
+    <text x="30" y="56" text-anchor="middle" font-family="Arial, sans-serif" font-size="44" fill="#f11300" font-weight="bold">!</text>
+    <text x="30" y="84" text-anchor="middle" font-family="Arial, sans-serif" font-size="11" fill="#000" font-weight="bold">but...</text>
+    <text x="30" y="100" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#000">JS blocking</text>
+  </g>
+  <g transform="translate(40,190)">
     <rect x="0" y="0" width="320" height="68" fill="#fff" stroke="#000" stroke-width="2"/>
     <text x="10" y="18" font-family="Arial, sans-serif" font-size="12" fill="#000" font-weight="bold">Page paint timeline</text>
     <rect x="10" y="28" width="60" height="18" fill="#fd0" stroke="#000" stroke-width="1"/>
@@ -13,26 +34,5 @@
     <text x="184" y="60" text-anchor="middle" font-family="Arial, sans-serif" font-size="9" fill="#000">paint</text>
     <text x="236" y="60" text-anchor="middle" font-family="Arial, sans-serif" font-size="9" fill="#000">long task</text>
     <text x="284" y="60" text-anchor="middle" font-family="Arial, sans-serif" font-size="9" fill="#000">idle</text>
-  </g>
-  <g transform="translate(40,170)">
-    <circle cx="40" cy="40" r="32" fill="#fd0" stroke="#000" stroke-width="3"/>
-    <circle cx="40" cy="40" r="12" fill="#000"/>
-    <text x="40" y="94" text-anchor="middle" font-family="Arial, sans-serif" font-size="13" fill="#000" font-weight="bold">SEE</text>
-    <text x="40" y="110" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#000">page is painted</text>
-  </g>
-  <g stroke="#0085f1" stroke-width="3" fill="none" stroke-linecap="round">
-    <path d="M85 210 L165 210"/>
-  </g>
-  <polygon points="165,205 178,210 165,215" fill="#0085f1"/>
-  <g transform="translate(180,180)">
-    <rect x="0" y="10" width="120" height="56" fill="#ffa400" stroke="#000" stroke-width="3"/>
-    <text x="60" y="44" text-anchor="middle" font-family="Arial, sans-serif" font-size="16" fill="#000" font-weight="bold">Click me</text>
-    <text x="60" y="84" text-anchor="middle" font-family="Arial, sans-serif" font-size="13" fill="#000" font-weight="bold">DO</text>
-    <text x="60" y="100" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#000">page should respond</text>
-  </g>
-  <g transform="translate(310,180)">
-    <text x="30" y="56" text-anchor="middle" font-family="Arial, sans-serif" font-size="44" fill="#f11300" font-weight="bold">!</text>
-    <text x="30" y="84" text-anchor="middle" font-family="Arial, sans-serif" font-size="11" fill="#000" font-weight="bold">but...</text>
-    <text x="30" y="100" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#000">JS blocking</text>
   </g>
 </svg>

--- a/src/assets/see_and_do_thumbnail.svg
+++ b/src/assets/see_and_do_thumbnail.svg
@@ -10,32 +10,32 @@
     <path d="M85 100 L165 100"/>
   </g>
   <polygon points="165,95 178,100 165,105" fill="#0085f1"/>
-  <g transform="translate(180,70)">
-    <rect x="0" y="10" width="120" height="56" fill="#fff" stroke="#000" stroke-width="3"/>
-    <text x="60" y="44" text-anchor="middle" font-family="Arial, sans-serif" font-size="16" fill="#000" font-weight="bold">Click me</text>
-    <text x="60" y="84" text-anchor="middle" font-family="Arial, sans-serif" font-size="13" fill="#000" font-weight="bold">DO</text>
-    <text x="60" y="100" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#000">page should respond</text>
+  <g transform="translate(180,72)">
+    <rect x="0" y="0" width="120" height="56" rx="6" fill="#fafafa" stroke="#888" stroke-width="1"/>
+    <text x="60" y="34" text-anchor="middle" font-family="Arial, sans-serif" font-size="16" fill="#000" font-weight="bold">Click me</text>
+    <text x="60" y="82" text-anchor="middle" font-family="Arial, sans-serif" font-size="13" fill="#000" font-weight="bold">DO</text>
+    <text x="60" y="98" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#000">page should respond</text>
   </g>
-  <g transform="translate(310,70)">
+  <g transform="translate(310,60)">
     <text x="30" y="56" text-anchor="middle" font-family="Arial, sans-serif" font-size="44" fill="#f11300" font-weight="bold">!</text>
-    <text x="30" y="84" text-anchor="middle" font-family="Arial, sans-serif" font-size="11" fill="#000" font-weight="bold">but...</text>
-    <text x="30" y="100" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#000">JS is late/blocking</text>
+    <text x="30" y="94" text-anchor="middle" font-family="Arial, sans-serif" font-size="11" fill="#000" font-weight="bold">but...</text>
+    <text x="30" y="110" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#000">JS is late/blocking</text>
   </g>
-  <g transform="translate(40,190)">
-    <rect x="0" y="0" width="320" height="100" fill="#fff" stroke="#000" stroke-width="2"/>
+  <g transform="translate(0,190)">
+    <rect x="0" y="0" width="400" height="100" fill="#fff" stroke="#000" stroke-width="2"/>
     <text x="10" y="14" font-family="Arial, sans-serif" font-size="12" fill="#000" font-weight="bold">Page paint timeline</text>
-    <text x="6" y="35" font-family="Arial, sans-serif" font-size="10" fill="#000">Paint</text>
-    <rect x="40" y="24" width="20" height="14" fill="#0d8043" stroke="#000" stroke-width="1"/>
-    <text x="50" y="35" text-anchor="middle" font-family="Arial, sans-serif" font-size="8" fill="#fff" font-weight="bold">CSS</text>
-    <rect x="60" y="24" width="24" height="14" fill="#a142f4" stroke="#000" stroke-width="1"/>
-    <text x="14" y="57" font-family="Arial, sans-serif" font-size="10" fill="#000">JS</text>
-    <rect x="40" y="46" width="120" height="14" fill="#ffd54f" stroke="#000" stroke-width="1"/>
-    <text x="125" y="57" text-anchor="middle" font-family="Arial, sans-serif" font-size="9" fill="#000">JS loading</text>
-    <rect x="160" y="46" width="80" height="14" fill="#ef5350" stroke="#000" stroke-width="1"/>
-    <text x="200" y="57" text-anchor="middle" font-family="Arial, sans-serif" font-size="9" fill="#000">long task</text>
-    <line x1="84" y1="20" x2="84" y2="66" stroke="#000" stroke-width="1" stroke-dasharray="3 2"/>
-    <text x="84" y="80" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#000" font-weight="bold">visible</text>
-    <line x1="240" y1="20" x2="240" y2="66" stroke="#000" stroke-width="1" stroke-dasharray="3 2"/>
-    <text x="240" y="80" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#000" font-weight="bold">interactive</text>
+    <text x="8" y="35" font-family="Arial, sans-serif" font-size="10" fill="#000">Paint</text>
+    <rect x="44" y="24" width="24" height="14" fill="#0d8043" stroke="#000" stroke-width="1"/>
+    <text x="56" y="35" text-anchor="middle" font-family="Arial, sans-serif" font-size="8" fill="#fff" font-weight="bold">CSS</text>
+    <rect x="68" y="24" width="40" height="14" fill="#a142f4" stroke="#000" stroke-width="1"/>
+    <text x="16" y="57" font-family="Arial, sans-serif" font-size="10" fill="#000">JS</text>
+    <rect x="44" y="46" width="200" height="14" fill="#ffd54f" stroke="#000" stroke-width="1"/>
+    <text x="144" y="57" text-anchor="middle" font-family="Arial, sans-serif" font-size="9" fill="#000">JS loading</text>
+    <rect x="244" y="46" width="120" height="14" fill="#ef5350" stroke="#000" stroke-width="1"/>
+    <text x="304" y="57" text-anchor="middle" font-family="Arial, sans-serif" font-size="9" fill="#000">long task</text>
+    <line x1="108" y1="20" x2="108" y2="66" stroke="#000" stroke-width="1" stroke-dasharray="3 2"/>
+    <text x="108" y="80" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#000" font-weight="bold">visible</text>
+    <line x1="364" y1="20" x2="364" y2="66" stroke="#000" stroke-width="1" stroke-dasharray="3 2"/>
+    <text x="364" y="80" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#000" font-weight="bold">interactive</text>
   </g>
 </svg>

--- a/src/assets/see_and_do_thumbnail.svg
+++ b/src/assets/see_and_do_thumbnail.svg
@@ -19,7 +19,7 @@
   <g transform="translate(310,70)">
     <text x="30" y="56" text-anchor="middle" font-family="Arial, sans-serif" font-size="44" fill="#f11300" font-weight="bold">!</text>
     <text x="30" y="84" text-anchor="middle" font-family="Arial, sans-serif" font-size="11" fill="#000" font-weight="bold">but...</text>
-    <text x="30" y="100" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#000">JS blocking</text>
+    <text x="30" y="100" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#000">JS is late/blocking</text>
   </g>
   <g transform="translate(40,190)">
     <rect x="0" y="0" width="320" height="100" fill="#fff" stroke="#000" stroke-width="2"/>

--- a/src/assets/see_and_do_thumbnail.svg
+++ b/src/assets/see_and_do_thumbnail.svg
@@ -1,0 +1,39 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 300" width="400" height="300">
+  <rect width="400" height="300" fill="#fff4de"/>
+  <text x="200" y="36" text-anchor="middle" font-family="sans-serif" font-size="20" fill="#5a4a2e" font-weight="bold">Visible should mean usable</text>
+  <g transform="translate(40,72)">
+    <rect x="0" y="0" width="320" height="60" fill="#fff8eb" stroke="#a98c5a" stroke-width="2" rx="6"/>
+    <text x="10" y="22" font-family="sans-serif" font-size="12" fill="#5a4a2e" font-weight="bold">Page paint timeline</text>
+    <rect x="10" y="32" width="60" height="14" fill="#a98c5a"/>
+    <rect x="74" y="32" width="80" height="14" fill="#c9b48a"/>
+    <rect x="158" y="32" width="60" height="14" fill="#a98c5a"/>
+    <rect x="222" y="32" width="40" height="14" fill="#c9b48a"/>
+    <rect x="266" y="32" width="44" height="14" fill="#a98c5a"/>
+    <text x="40" y="58" text-anchor="middle" font-family="sans-serif" font-size="9" fill="#5a4a2e">paint</text>
+    <text x="114" y="58" text-anchor="middle" font-family="sans-serif" font-size="9" fill="#a3550e">long task</text>
+    <text x="188" y="58" text-anchor="middle" font-family="sans-serif" font-size="9" fill="#5a4a2e">paint</text>
+    <text x="242" y="58" text-anchor="middle" font-family="sans-serif" font-size="9" fill="#a3550e">long task</text>
+    <text x="288" y="58" text-anchor="middle" font-family="sans-serif" font-size="9" fill="#5a4a2e">idle</text>
+  </g>
+  <g transform="translate(40,170)">
+    <circle cx="40" cy="40" r="32" fill="#fff8eb" stroke="#a98c5a" stroke-width="3"/>
+    <circle cx="40" cy="40" r="12" fill="#a98c5a"/>
+    <text x="40" y="92" text-anchor="middle" font-family="sans-serif" font-size="12" fill="#5a4a2e" font-weight="bold">SEE</text>
+    <text x="40" y="106" text-anchor="middle" font-family="sans-serif" font-size="10" fill="#5a4a2e">page is painted</text>
+  </g>
+  <g stroke="#a98c5a" stroke-width="3" fill="none" stroke-linecap="round">
+    <path d="M120 210 L160 210" />
+    <path d="M120 210 L160 210" stroke-dasharray="4 4"/>
+  </g>
+  <g transform="translate(170,170)">
+    <rect x="0" y="20" width="120" height="40" rx="6" fill="#a98c5a"/>
+    <text x="60" y="46" text-anchor="middle" font-family="sans-serif" font-size="14" fill="#fff8eb" font-weight="bold">Click me</text>
+    <text x="60" y="92" text-anchor="middle" font-family="sans-serif" font-size="12" fill="#5a4a2e" font-weight="bold">DO</text>
+    <text x="60" y="106" text-anchor="middle" font-family="sans-serif" font-size="10" fill="#5a4a2e">page should respond</text>
+  </g>
+  <g transform="translate(310,170)">
+    <text x="22" y="46" text-anchor="middle" font-family="sans-serif" font-size="32" fill="#a3550e" font-weight="bold">!</text>
+    <text x="22" y="92" text-anchor="middle" font-family="sans-serif" font-size="12" fill="#5a4a2e" font-weight="bold">but...</text>
+    <text x="22" y="106" text-anchor="middle" font-family="sans-serif" font-size="10" fill="#5a4a2e">JS blocking</text>
+  </g>
+</svg>

--- a/src/assets/see_and_do_thumbnail.svg
+++ b/src/assets/see_and_do_thumbnail.svg
@@ -25,16 +25,16 @@
     <rect x="0" y="0" width="320" height="100" fill="#fff" stroke="#000" stroke-width="2"/>
     <text x="10" y="14" font-family="Arial, sans-serif" font-size="12" fill="#000" font-weight="bold">Page paint timeline</text>
     <text x="6" y="35" font-family="Arial, sans-serif" font-size="10" fill="#000">Paint</text>
-    <rect x="40" y="24" width="22" height="14" fill="#a142f4" stroke="#000" stroke-width="1"/>
-    <rect x="78" y="24" width="14" height="14" fill="#a142f4" stroke="#000" stroke-width="1"/>
-    <rect x="120" y="24" width="40" height="14" fill="#a142f4" stroke="#000" stroke-width="1"/>
+    <rect x="40" y="24" width="20" height="14" fill="#0d8043" stroke="#000" stroke-width="1"/>
+    <text x="50" y="35" text-anchor="middle" font-family="Arial, sans-serif" font-size="8" fill="#fff" font-weight="bold">CSS</text>
+    <rect x="60" y="24" width="24" height="14" fill="#a142f4" stroke="#000" stroke-width="1"/>
     <text x="14" y="57" font-family="Arial, sans-serif" font-size="10" fill="#000">JS</text>
     <rect x="40" y="46" width="120" height="14" fill="#ffd54f" stroke="#000" stroke-width="1"/>
-    <text x="100" y="57" text-anchor="middle" font-family="Arial, sans-serif" font-size="9" fill="#000">JS loading</text>
+    <text x="125" y="57" text-anchor="middle" font-family="Arial, sans-serif" font-size="9" fill="#000">JS loading</text>
     <rect x="160" y="46" width="80" height="14" fill="#ef5350" stroke="#000" stroke-width="1"/>
     <text x="200" y="57" text-anchor="middle" font-family="Arial, sans-serif" font-size="9" fill="#000">long task</text>
-    <line x1="160" y1="20" x2="160" y2="66" stroke="#000" stroke-width="1" stroke-dasharray="3 2"/>
-    <text x="160" y="80" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#000" font-weight="bold">visible</text>
+    <line x1="84" y1="20" x2="84" y2="66" stroke="#000" stroke-width="1" stroke-dasharray="3 2"/>
+    <text x="84" y="80" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#000" font-weight="bold">visible</text>
     <line x1="240" y1="20" x2="240" y2="66" stroke="#000" stroke-width="1" stroke-dasharray="3 2"/>
     <text x="240" y="80" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#000" font-weight="bold">interactive</text>
   </g>

--- a/src/assets/see_and_do_thumbnail.svg
+++ b/src/assets/see_and_do_thumbnail.svg
@@ -24,10 +24,10 @@
   <g transform="translate(40,190)">
     <rect x="0" y="0" width="320" height="68" fill="#fff" stroke="#000" stroke-width="2"/>
     <text x="10" y="18" font-family="Arial, sans-serif" font-size="12" fill="#000" font-weight="bold">Page paint timeline</text>
-    <rect x="10" y="28" width="60" height="18" fill="#fff" stroke="#000" stroke-width="1"/>
-    <rect x="72" y="28" width="80" height="18" fill="#f11300" fill-opacity="0.2" stroke="#000" stroke-width="1"/>
-    <rect x="154" y="28" width="60" height="18" fill="#fff" stroke="#000" stroke-width="1"/>
-    <rect x="216" y="28" width="40" height="18" fill="#f11300" fill-opacity="0.2" stroke="#000" stroke-width="1"/>
+    <rect x="10" y="28" width="60" height="18" fill="#a142f4" stroke="#000" stroke-width="1"/>
+    <rect x="72" y="28" width="80" height="18" fill="#ef5350" stroke="#000" stroke-width="1"/>
+    <rect x="154" y="28" width="60" height="18" fill="#a142f4" stroke="#000" stroke-width="1"/>
+    <rect x="216" y="28" width="40" height="18" fill="#ef5350" stroke="#000" stroke-width="1"/>
     <rect x="258" y="28" width="52" height="18" fill="#fff" stroke="#000" stroke-width="1"/>
     <text x="40" y="60" text-anchor="middle" font-family="Arial, sans-serif" font-size="9" fill="#000">paint</text>
     <text x="112" y="60" text-anchor="middle" font-family="Arial, sans-serif" font-size="9" fill="#000">long task</text>

--- a/src/assets/see_and_do_thumbnail.svg
+++ b/src/assets/see_and_do_thumbnail.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 50 400 250" width="400" height="250">
   <rect width="400" height="300" fill="#fff" />
-  <g transform="translate(40,60)">
+  <g transform="translate(25,60)">
     <circle cx="40" cy="40" r="32" fill="#fff" stroke="#000" stroke-width="3" />
     <circle cx="40" cy="40" r="12" fill="#000" />
     <text x="40" y="94" text-anchor="middle" font-family="Arial, sans-serif" font-size="13" fill="#000"
@@ -9,10 +9,10 @@
       painted</text>
   </g>
   <g stroke="#0085f1" stroke-width="3" fill="none" stroke-linecap="round">
-    <path d="M85 100 L165 100" />
+    <path d="M70 100 L150 100" />
   </g>
-  <polygon points="165,95 178,100 165,105" fill="#0085f1" />
-  <g transform="translate(180,72)">
+  <polygon points="150,95 163,100 150,105" fill="#0085f1" />
+  <g transform="translate(165,72)">
     <rect x="0" y="0" width="120" height="56" rx="6" fill="#fafafa" stroke="#888" stroke-width="1" />
     <text x="60" y="34" text-anchor="middle" font-family="Arial, sans-serif" font-size="16" fill="#000"
       font-weight="bold">Click me</text>
@@ -21,7 +21,7 @@
     <text x="60" y="98" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#000">page should
       respond</text>
   </g>
-  <g transform="translate(310,60)">
+  <g transform="translate(295,60)">
     <text x="30" y="56" text-anchor="middle" font-family="Arial, sans-serif" font-size="44" fill="#f11300"
       font-weight="bold">!</text>
     <text x="30" y="94" text-anchor="middle" font-family="Arial, sans-serif" font-size="11" fill="#000"

--- a/src/assets/see_and_do_thumbnail.svg
+++ b/src/assets/see_and_do_thumbnail.svg
@@ -1,39 +1,39 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 300" width="400" height="300">
-  <rect width="400" height="300" fill="#fff4de"/>
-  <text x="200" y="36" text-anchor="middle" font-family="sans-serif" font-size="20" fill="#5a4a2e" font-weight="bold">Visible should mean usable</text>
-  <g transform="translate(40,72)">
-    <rect x="0" y="0" width="320" height="60" fill="#fff8eb" stroke="#a98c5a" stroke-width="2" rx="6"/>
-    <text x="10" y="22" font-family="sans-serif" font-size="12" fill="#5a4a2e" font-weight="bold">Page paint timeline</text>
-    <rect x="10" y="32" width="60" height="14" fill="#a98c5a"/>
-    <rect x="74" y="32" width="80" height="14" fill="#c9b48a"/>
-    <rect x="158" y="32" width="60" height="14" fill="#a98c5a"/>
-    <rect x="222" y="32" width="40" height="14" fill="#c9b48a"/>
-    <rect x="266" y="32" width="44" height="14" fill="#a98c5a"/>
-    <text x="40" y="58" text-anchor="middle" font-family="sans-serif" font-size="9" fill="#5a4a2e">paint</text>
-    <text x="114" y="58" text-anchor="middle" font-family="sans-serif" font-size="9" fill="#a3550e">long task</text>
-    <text x="188" y="58" text-anchor="middle" font-family="sans-serif" font-size="9" fill="#5a4a2e">paint</text>
-    <text x="242" y="58" text-anchor="middle" font-family="sans-serif" font-size="9" fill="#a3550e">long task</text>
-    <text x="288" y="58" text-anchor="middle" font-family="sans-serif" font-size="9" fill="#5a4a2e">idle</text>
+  <rect width="400" height="300" fill="#fff"/>
+  <text x="200" y="34" text-anchor="middle" font-family="Arial, sans-serif" font-size="20" fill="#000" font-weight="bold">Visible should mean usable</text>
+  <g transform="translate(40,60)">
+    <rect x="0" y="0" width="320" height="68" fill="#fff" stroke="#000" stroke-width="2"/>
+    <text x="10" y="18" font-family="Arial, sans-serif" font-size="12" fill="#000" font-weight="bold">Page paint timeline</text>
+    <rect x="10" y="28" width="60" height="18" fill="#fd0" stroke="#000" stroke-width="1"/>
+    <rect x="72" y="28" width="80" height="18" fill="#ffa400" stroke="#000" stroke-width="1"/>
+    <rect x="154" y="28" width="60" height="18" fill="#fd0" stroke="#000" stroke-width="1"/>
+    <rect x="216" y="28" width="40" height="18" fill="#ffa400" stroke="#000" stroke-width="1"/>
+    <rect x="258" y="28" width="52" height="18" fill="#fd0" stroke="#000" stroke-width="1"/>
+    <text x="40" y="60" text-anchor="middle" font-family="Arial, sans-serif" font-size="9" fill="#000">paint</text>
+    <text x="112" y="60" text-anchor="middle" font-family="Arial, sans-serif" font-size="9" fill="#000">long task</text>
+    <text x="184" y="60" text-anchor="middle" font-family="Arial, sans-serif" font-size="9" fill="#000">paint</text>
+    <text x="236" y="60" text-anchor="middle" font-family="Arial, sans-serif" font-size="9" fill="#000">long task</text>
+    <text x="284" y="60" text-anchor="middle" font-family="Arial, sans-serif" font-size="9" fill="#000">idle</text>
   </g>
   <g transform="translate(40,170)">
-    <circle cx="40" cy="40" r="32" fill="#fff8eb" stroke="#a98c5a" stroke-width="3"/>
-    <circle cx="40" cy="40" r="12" fill="#a98c5a"/>
-    <text x="40" y="92" text-anchor="middle" font-family="sans-serif" font-size="12" fill="#5a4a2e" font-weight="bold">SEE</text>
-    <text x="40" y="106" text-anchor="middle" font-family="sans-serif" font-size="10" fill="#5a4a2e">page is painted</text>
+    <circle cx="40" cy="40" r="32" fill="#fd0" stroke="#000" stroke-width="3"/>
+    <circle cx="40" cy="40" r="12" fill="#000"/>
+    <text x="40" y="94" text-anchor="middle" font-family="Arial, sans-serif" font-size="13" fill="#000" font-weight="bold">SEE</text>
+    <text x="40" y="110" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#000">page is painted</text>
   </g>
-  <g stroke="#a98c5a" stroke-width="3" fill="none" stroke-linecap="round">
-    <path d="M120 210 L160 210" />
-    <path d="M120 210 L160 210" stroke-dasharray="4 4"/>
+  <g stroke="#0085f1" stroke-width="3" fill="none" stroke-linecap="round">
+    <path d="M85 210 L165 210"/>
   </g>
-  <g transform="translate(170,170)">
-    <rect x="0" y="20" width="120" height="40" rx="6" fill="#a98c5a"/>
-    <text x="60" y="46" text-anchor="middle" font-family="sans-serif" font-size="14" fill="#fff8eb" font-weight="bold">Click me</text>
-    <text x="60" y="92" text-anchor="middle" font-family="sans-serif" font-size="12" fill="#5a4a2e" font-weight="bold">DO</text>
-    <text x="60" y="106" text-anchor="middle" font-family="sans-serif" font-size="10" fill="#5a4a2e">page should respond</text>
+  <polygon points="165,205 178,210 165,215" fill="#0085f1"/>
+  <g transform="translate(180,180)">
+    <rect x="0" y="10" width="120" height="56" fill="#ffa400" stroke="#000" stroke-width="3"/>
+    <text x="60" y="44" text-anchor="middle" font-family="Arial, sans-serif" font-size="16" fill="#000" font-weight="bold">Click me</text>
+    <text x="60" y="84" text-anchor="middle" font-family="Arial, sans-serif" font-size="13" fill="#000" font-weight="bold">DO</text>
+    <text x="60" y="100" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#000">page should respond</text>
   </g>
-  <g transform="translate(310,170)">
-    <text x="22" y="46" text-anchor="middle" font-family="sans-serif" font-size="32" fill="#a3550e" font-weight="bold">!</text>
-    <text x="22" y="92" text-anchor="middle" font-family="sans-serif" font-size="12" fill="#5a4a2e" font-weight="bold">but...</text>
-    <text x="22" y="106" text-anchor="middle" font-family="sans-serif" font-size="10" fill="#5a4a2e">JS blocking</text>
+  <g transform="translate(310,180)">
+    <text x="30" y="56" text-anchor="middle" font-family="Arial, sans-serif" font-size="44" fill="#f11300" font-weight="bold">!</text>
+    <text x="30" y="84" text-anchor="middle" font-family="Arial, sans-serif" font-size="11" fill="#000" font-weight="bold">but...</text>
+    <text x="30" y="100" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#000">JS blocking</text>
   </g>
 </svg>

--- a/src/assets/see_and_do_thumbnail.svg
+++ b/src/assets/see_and_do_thumbnail.svg
@@ -22,17 +22,20 @@
     <text x="30" y="100" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#000">JS blocking</text>
   </g>
   <g transform="translate(40,190)">
-    <rect x="0" y="0" width="320" height="68" fill="#fff" stroke="#000" stroke-width="2"/>
-    <text x="10" y="18" font-family="Arial, sans-serif" font-size="12" fill="#000" font-weight="bold">Page paint timeline</text>
-    <rect x="10" y="28" width="60" height="18" fill="#a142f4" stroke="#000" stroke-width="1"/>
-    <rect x="72" y="28" width="80" height="18" fill="#ef5350" stroke="#000" stroke-width="1"/>
-    <rect x="154" y="28" width="60" height="18" fill="#a142f4" stroke="#000" stroke-width="1"/>
-    <rect x="216" y="28" width="40" height="18" fill="#ef5350" stroke="#000" stroke-width="1"/>
-    <rect x="258" y="28" width="52" height="18" fill="#fff" stroke="#000" stroke-width="1"/>
-    <text x="40" y="60" text-anchor="middle" font-family="Arial, sans-serif" font-size="9" fill="#000">paint</text>
-    <text x="112" y="60" text-anchor="middle" font-family="Arial, sans-serif" font-size="9" fill="#000">long task</text>
-    <text x="184" y="60" text-anchor="middle" font-family="Arial, sans-serif" font-size="9" fill="#000">paint</text>
-    <text x="236" y="60" text-anchor="middle" font-family="Arial, sans-serif" font-size="9" fill="#000">long task</text>
-    <text x="284" y="60" text-anchor="middle" font-family="Arial, sans-serif" font-size="9" fill="#000">idle</text>
+    <rect x="0" y="0" width="320" height="100" fill="#fff" stroke="#000" stroke-width="2"/>
+    <text x="10" y="14" font-family="Arial, sans-serif" font-size="12" fill="#000" font-weight="bold">Page paint timeline</text>
+    <text x="6" y="35" font-family="Arial, sans-serif" font-size="10" fill="#000">Paint</text>
+    <rect x="40" y="24" width="22" height="14" fill="#a142f4" stroke="#000" stroke-width="1"/>
+    <rect x="78" y="24" width="14" height="14" fill="#a142f4" stroke="#000" stroke-width="1"/>
+    <rect x="120" y="24" width="40" height="14" fill="#a142f4" stroke="#000" stroke-width="1"/>
+    <text x="14" y="57" font-family="Arial, sans-serif" font-size="10" fill="#000">JS</text>
+    <rect x="40" y="46" width="120" height="14" fill="#ffd54f" stroke="#000" stroke-width="1"/>
+    <text x="100" y="57" text-anchor="middle" font-family="Arial, sans-serif" font-size="9" fill="#000">JS loading</text>
+    <rect x="160" y="46" width="80" height="14" fill="#ef5350" stroke="#000" stroke-width="1"/>
+    <text x="200" y="57" text-anchor="middle" font-family="Arial, sans-serif" font-size="9" fill="#000">long task</text>
+    <line x1="160" y1="20" x2="160" y2="66" stroke="#000" stroke-width="1" stroke-dasharray="3 2"/>
+    <text x="160" y="80" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#000" font-weight="bold">visible</text>
+    <line x1="240" y1="20" x2="240" y2="66" stroke="#000" stroke-width="1" stroke-dasharray="3 2"/>
+    <text x="240" y="80" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#000" font-weight="bold">interactive</text>
   </g>
 </svg>

--- a/src/assets/see_and_do_thumbnail.svg
+++ b/src/assets/see_and_do_thumbnail.svg
@@ -1,41 +1,54 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 50 400 250" width="400" height="250">
-  <rect width="400" height="300" fill="#fff"/>
+  <rect width="400" height="300" fill="#fff" />
   <g transform="translate(40,60)">
-    <circle cx="40" cy="40" r="32" fill="#fff" stroke="#000" stroke-width="3"/>
-    <circle cx="40" cy="40" r="12" fill="#000"/>
-    <text x="40" y="94" text-anchor="middle" font-family="Arial, sans-serif" font-size="13" fill="#000" font-weight="bold">SEE</text>
-    <text x="40" y="110" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#000">page is painted</text>
+    <circle cx="40" cy="40" r="32" fill="#fff" stroke="#000" stroke-width="3" />
+    <circle cx="40" cy="40" r="12" fill="#000" />
+    <text x="40" y="94" text-anchor="middle" font-family="Arial, sans-serif" font-size="13" fill="#000"
+      font-weight="bold">SEE</text>
+    <text x="40" y="110" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#000">page is
+      painted</text>
   </g>
   <g stroke="#0085f1" stroke-width="3" fill="none" stroke-linecap="round">
-    <path d="M85 100 L165 100"/>
+    <path d="M85 100 L165 100" />
   </g>
-  <polygon points="165,95 178,100 165,105" fill="#0085f1"/>
+  <polygon points="165,95 178,100 165,105" fill="#0085f1" />
   <g transform="translate(180,72)">
-    <rect x="0" y="0" width="120" height="56" rx="6" fill="#fafafa" stroke="#888" stroke-width="1"/>
-    <text x="60" y="34" text-anchor="middle" font-family="Arial, sans-serif" font-size="16" fill="#000" font-weight="bold">Click me</text>
-    <text x="60" y="82" text-anchor="middle" font-family="Arial, sans-serif" font-size="13" fill="#000" font-weight="bold">DO</text>
-    <text x="60" y="98" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#000">page should respond</text>
+    <rect x="0" y="0" width="120" height="56" rx="6" fill="#fafafa" stroke="#888" stroke-width="1" />
+    <text x="60" y="34" text-anchor="middle" font-family="Arial, sans-serif" font-size="16" fill="#000"
+      font-weight="bold">Click me</text>
+    <text x="60" y="82" text-anchor="middle" font-family="Arial, sans-serif" font-size="13" fill="#000"
+      font-weight="bold">DO</text>
+    <text x="60" y="98" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#000">page should
+      respond</text>
   </g>
   <g transform="translate(310,60)">
-    <text x="30" y="56" text-anchor="middle" font-family="Arial, sans-serif" font-size="44" fill="#f11300" font-weight="bold">!</text>
-    <text x="30" y="94" text-anchor="middle" font-family="Arial, sans-serif" font-size="11" fill="#000" font-weight="bold">but...</text>
-    <text x="30" y="110" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#000">JS is late/blocking</text>
+    <text x="30" y="56" text-anchor="middle" font-family="Arial, sans-serif" font-size="44" fill="#f11300"
+      font-weight="bold">!</text>
+    <text x="30" y="94" text-anchor="middle" font-family="Arial, sans-serif" font-size="11" fill="#000"
+      font-weight="bold">but...</text>
+    <text x="30" y="110" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#000">JS is
+      late/blocking</text>
   </g>
   <g transform="translate(0,190)">
-    <rect x="0" y="0" width="400" height="100" fill="#fff" stroke="#000" stroke-width="2"/>
-    <text x="10" y="14" font-family="Arial, sans-serif" font-size="12" fill="#000" font-weight="bold">Page paint timeline</text>
-    <text x="8" y="35" font-family="Arial, sans-serif" font-size="10" fill="#000">Paint</text>
-    <rect x="44" y="24" width="24" height="14" fill="#0d8043" stroke="#000" stroke-width="1"/>
-    <text x="56" y="35" text-anchor="middle" font-family="Arial, sans-serif" font-size="8" fill="#fff" font-weight="bold">CSS</text>
-    <rect x="68" y="24" width="40" height="14" fill="#a142f4" stroke="#000" stroke-width="1"/>
-    <text x="16" y="57" font-family="Arial, sans-serif" font-size="10" fill="#000">JS</text>
-    <rect x="44" y="46" width="200" height="14" fill="#ffd54f" stroke="#000" stroke-width="1"/>
-    <text x="144" y="57" text-anchor="middle" font-family="Arial, sans-serif" font-size="9" fill="#000">JS loading</text>
-    <rect x="244" y="46" width="120" height="14" fill="#ef5350" stroke="#000" stroke-width="1"/>
-    <text x="304" y="57" text-anchor="middle" font-family="Arial, sans-serif" font-size="9" fill="#000">long task</text>
-    <line x1="108" y1="20" x2="108" y2="66" stroke="#000" stroke-width="1" stroke-dasharray="3 2"/>
-    <text x="108" y="80" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#000" font-weight="bold">visible</text>
-    <line x1="364" y1="20" x2="364" y2="66" stroke="#000" stroke-width="1" stroke-dasharray="3 2"/>
-    <text x="364" y="80" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#000" font-weight="bold">interactive</text>
+    <rect x="1" y="0" width="398" height="100" fill="#fff" stroke="#000" stroke-width="2" />
+    <text x="10" y="20" font-family="Arial, sans-serif" font-size="12" fill="#000" font-weight="bold">Page paint
+      timeline</text>
+    <text x="8" y="41" font-family="Arial, sans-serif" font-size="10" fill="#000">Paint</text>
+    <rect x="44" y="30" width="24" height="14" fill="#0d8043" stroke="#000" stroke-width="1" />
+    <text x="56" y="41" text-anchor="middle" font-family="Arial, sans-serif" font-size="8" fill="#fff"
+      font-weight="bold">CSS</text>
+    <rect x="68" y="30" width="40" height="14" fill="#a142f4" stroke="#000" stroke-width="1" />
+    <text x="16" y="63" font-family="Arial, sans-serif" font-size="10" fill="#000">JS</text>
+    <rect x="44" y="52" width="200" height="14" fill="#ffd54f" stroke="#000" stroke-width="1" />
+    <text x="144" y="63" text-anchor="middle" font-family="Arial, sans-serif" font-size="9" fill="#000">JS
+      loading</text>
+    <rect x="244" y="52" width="120" height="14" fill="#ef5350" stroke="#000" stroke-width="1" />
+    <text x="304" y="63" text-anchor="middle" font-family="Arial, sans-serif" font-size="9" fill="#000">long task</text>
+    <line x1="108" y1="26" x2="108" y2="72" stroke="#000" stroke-width="1" stroke-dasharray="3 2" />
+    <text x="108" y="86" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#000"
+      font-weight="bold">visible</text>
+    <line x1="364" y1="26" x2="364" y2="72" stroke="#000" stroke-width="1" stroke-dasharray="3 2" />
+    <text x="364" y="86" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#000"
+      font-weight="bold">interactive</text>
   </g>
 </svg>

--- a/src/assets/see_and_do_thumbnail.svg
+++ b/src/assets/see_and_do_thumbnail.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 50 400 250" width="400" height="250">
   <rect width="400" height="300" fill="#fff"/>
   <g transform="translate(40,60)">
-    <circle cx="40" cy="40" r="32" fill="#fd0" stroke="#000" stroke-width="3"/>
+    <circle cx="40" cy="40" r="32" fill="#fff" stroke="#000" stroke-width="3"/>
     <circle cx="40" cy="40" r="12" fill="#000"/>
     <text x="40" y="94" text-anchor="middle" font-family="Arial, sans-serif" font-size="13" fill="#000" font-weight="bold">SEE</text>
     <text x="40" y="110" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#000">page is painted</text>
@@ -11,7 +11,7 @@
   </g>
   <polygon points="165,95 178,100 165,105" fill="#0085f1"/>
   <g transform="translate(180,70)">
-    <rect x="0" y="10" width="120" height="56" fill="#ffa400" stroke="#000" stroke-width="3"/>
+    <rect x="0" y="10" width="120" height="56" fill="#fff" stroke="#000" stroke-width="3"/>
     <text x="60" y="44" text-anchor="middle" font-family="Arial, sans-serif" font-size="16" fill="#000" font-weight="bold">Click me</text>
     <text x="60" y="84" text-anchor="middle" font-family="Arial, sans-serif" font-size="13" fill="#000" font-weight="bold">DO</text>
     <text x="60" y="100" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#000">page should respond</text>
@@ -24,11 +24,11 @@
   <g transform="translate(40,190)">
     <rect x="0" y="0" width="320" height="68" fill="#fff" stroke="#000" stroke-width="2"/>
     <text x="10" y="18" font-family="Arial, sans-serif" font-size="12" fill="#000" font-weight="bold">Page paint timeline</text>
-    <rect x="10" y="28" width="60" height="18" fill="#fd0" stroke="#000" stroke-width="1"/>
-    <rect x="72" y="28" width="80" height="18" fill="#ffa400" stroke="#000" stroke-width="1"/>
-    <rect x="154" y="28" width="60" height="18" fill="#fd0" stroke="#000" stroke-width="1"/>
-    <rect x="216" y="28" width="40" height="18" fill="#ffa400" stroke="#000" stroke-width="1"/>
-    <rect x="258" y="28" width="52" height="18" fill="#fd0" stroke="#000" stroke-width="1"/>
+    <rect x="10" y="28" width="60" height="18" fill="#fff" stroke="#000" stroke-width="1"/>
+    <rect x="72" y="28" width="80" height="18" fill="#f11300" fill-opacity="0.2" stroke="#000" stroke-width="1"/>
+    <rect x="154" y="28" width="60" height="18" fill="#fff" stroke="#000" stroke-width="1"/>
+    <rect x="216" y="28" width="40" height="18" fill="#f11300" fill-opacity="0.2" stroke="#000" stroke-width="1"/>
+    <rect x="258" y="28" width="52" height="18" fill="#fff" stroke="#000" stroke-width="1"/>
     <text x="40" y="60" text-anchor="middle" font-family="Arial, sans-serif" font-size="9" fill="#000">paint</text>
     <text x="112" y="60" text-anchor="middle" font-family="Arial, sans-serif" font-size="9" fill="#000">long task</text>
     <text x="184" y="60" text-anchor="middle" font-family="Arial, sans-serif" font-size="9" fill="#000">paint</text>

--- a/src/patterns/see_and_do.md
+++ b/src/patterns/see_and_do.md
@@ -24,8 +24,8 @@ The user's experience is "I tapped the button and nothing happened." From their 
 The user can see the page and the button (SEE), but a long task on the main thread is still blocking input — the click goes nowhere (DO).
 
 <figure>
-<figcaption>Visible should mean usable</figcaption>
 <img src="/assets/see_and_do_thumbnail.svg" width="400" alt="A page paint timeline showing alternating paint and long-task blocks; below it a circle marked SEE next to a button marked DO connected by a blue arrow, with a red exclamation mark indicating that JavaScript is blocking the click"/>
+<figcaption>Visible should mean usable</figcaption>
 </figure>
 
 ## Solution

--- a/src/patterns/see_and_do.md
+++ b/src/patterns/see_and_do.md
@@ -5,6 +5,7 @@ tags: pattern
 thumbnail: /assets/see_and_do_thumbnail.svg
 og_image: /assets/speed_patterns_og_image.jpg
 order: 10
+ai_assisted: true
 date: 2017-12-27
 authors:
     - name: Joseph Gannon

--- a/src/patterns/see_and_do.md
+++ b/src/patterns/see_and_do.md
@@ -1,0 +1,76 @@
+---
+layout: article.njk
+title: See and Do
+tags: pattern
+thumbnail: /assets/see_and_do_thumbnail.svg
+og_image: /assets/speed_patterns_og_image.jpg
+order: 10
+---
+
+When a user can see a button, they assume they can press it. When they can read a form field, they assume they can type into it. The mental model is simple: visible means usable. The web routinely violates this assumption — JavaScript is still parsing, hydrating, or executing long tasks during the seconds after first paint, and the page sits there looking interactive while not actually responding to input.
+
+<!-- excerpt -->
+
+## The Problem
+
+Modern web apps frequently have a window — sometimes a few hundred milliseconds, sometimes several seconds — between when content becomes visible and when the page is actually ready to handle interaction. During that window:
+
+- Clicks may be silently dropped because no event listener is attached yet.
+- Inputs may register keystrokes but not validate, autocomplete, or submit.
+- Long tasks on the main thread (script evaluation, framework hydration, expensive layout) block the event loop, so even queued events sit waiting.
+
+The user's experience is "I tapped the button and nothing happened." From their perspective, the site is broken. From the dev tools' perspective, the page is "loaded" — the metric just doesn't match the experience.
+
+## Solution
+
+Treat _interactivity_ as part of the loading experience, not a separate concern. The goal is to close the gap between "the user can see it" and "the user can use it" — ideally to zero.
+
+### 1. Measure the right thing
+
+Time-to-paint metrics like First Contentful Paint and Largest Contentful Paint don't tell you whether the page is responsive. The metrics that do:
+
+- **Interaction to Next Paint (INP)** — measures the latency of real user interactions. A page with bad INP looks fast and feels broken.
+- **Total Blocking Time (TBT)** — sums up the time the main thread is blocked by long tasks during load.
+- **Long Tasks API** — surfaces individual tasks longer than 50ms that prevent the page from responding to input. ([Long Tasks spec](https://www.w3.org/TR/longtasks/))
+- **Time to Interactive (TTI)** — when the page has been visually ready and the main thread has stayed quiet long enough to handle input.
+
+Watch INP and TBT in real-user monitoring, not just lab tests — the lab can hide problems that real devices and real interaction patterns expose.
+
+### 2. Don't render UI you can't yet operate
+
+If a control isn't ready to do its job, don't show it as if it were. Options:
+
+- **Render the control disabled** until its handler is wired up. The user can see it but visibly cannot use it yet — that mismatch is honest.
+- **Defer the entire feature** behind a placeholder, and swap it in only when its code is loaded. This is the [Convert on Arrival](/patterns/convert_on_arrival/) pattern.
+- **Server-render the form action** so a submit during the gap still works — the page progressively enhances rather than depending on JS for basic function.
+
+### 3. Break up long tasks
+
+The main thread is a single lane. While it's busy compiling a 400KB framework bundle or hydrating a thousand components, every user input is queued behind that work.
+
+- **Split work into smaller chunks** using `requestIdleCallback`, `scheduler.postTask`, or simple `setTimeout(0)` yields.
+- **Defer non-critical scripts** with `async`, `defer`, or dynamic imports gated by interaction.
+- **Avoid re-hydrating already-rendered server HTML** when possible — emerging patterns like resumability, islands, and selective hydration target exactly this cost.
+- **Audit third-party scripts.** Tag managers, analytics, A/B testing libraries and chat widgets are common sources of long tasks that block the page during the most visible part of load.
+
+### 4. Make critical input paths cheap
+
+Even when the rest of the page is busy, the path that handles "click the most important button on this view" should be reachable. If your hero CTA depends on a 200KB JS bundle that's still parsing, that's a design choice — usually the wrong one.
+
+## Why This Matters
+
+A site that scores well on paint metrics but fails on interactivity feels worse than one that paints a bit slower but is responsive from the moment things appear. Users don't measure performance in milliseconds — they measure it in trust. Every dropped click chips away at that trust.
+
+The "see and do" gap is also one of the easiest performance problems to overlook because most automated checks don't surface it. Watching INP, splitting long tasks, and resisting the urge to ship visually-finished but functionally-incomplete UI keeps the experience honest.
+
+## Related Patterns
+
+- [Acknowledge Actions](/patterns/acknowledge_actions/) — what to do once interaction is ready.
+- [Convert on Arrival](/patterns/convert_on_arrival/) — staging interactivity progressively.
+- [Skeletal Designs](/patterns/skeletal_designs/) — placeholders for content that isn't ready yet.
+
+## Resources
+
+- [Long Tasks API specification](https://www.w3.org/TR/longtasks/)
+- [Interaction to Next Paint (INP) on web.dev](https://web.dev/articles/inp)
+- [Total Blocking Time (TBT) on web.dev](https://web.dev/articles/tbt)

--- a/src/patterns/see_and_do.md
+++ b/src/patterns/see_and_do.md
@@ -21,8 +21,10 @@ Modern web apps frequently have a window — sometimes a few hundred millisecond
 
 The user's experience is "I tapped the button and nothing happened." From their perspective, the site is broken. From the dev tools' perspective, the page is "loaded" — the metric just doesn't match the experience.
 
+The user can see the page and the button (SEE), but a long task on the main thread is still blocking input — the click goes nowhere (DO).
+
 <figure>
-<figcaption>The user can see the page and the button (SEE), but a long task on the main thread is still blocking input — the click goes nowhere (DO).</figcaption>
+<figcaption>Visible should mean usable</figcaption>
 <img src="/assets/see_and_do_thumbnail.svg" width="400" alt="A page paint timeline showing alternating paint and long-task blocks; below it a circle marked SEE next to a button marked DO connected by a blue arrow, with a red exclamation mark indicating that JavaScript is blocking the click"/>
 </figure>
 

--- a/src/patterns/see_and_do.md
+++ b/src/patterns/see_and_do.md
@@ -15,9 +15,9 @@ When a user can see a button, they assume they can press it. When they can read 
 
 Modern web apps frequently have a window — sometimes a few hundred milliseconds, sometimes several seconds — between when content becomes visible and when the page is actually ready to handle interaction. During that window:
 
-- Clicks may be silently dropped because no event listener is attached yet.
-- Inputs may register keystrokes but not validate, autocomplete, or submit.
-- Long tasks on the main thread (script evaluation, framework hydration, expensive layout) block the event loop, so even queued events sit waiting.
+- Clicks may be silently dropped because no event listener is attached yet
+- Inputs may register keystrokes but not validate, autocomplete, or submit
+- Long tasks on the main thread (script evaluation, framework hydration, expensive layout) block the event loop, so even queued events sit waiting
 
 The user's experience is "I tapped the button and nothing happened." From their perspective, the site is broken. From the dev tools' perspective, the page is "loaded" — the metric just doesn't match the experience.
 
@@ -29,9 +29,9 @@ Treat _interactivity_ as part of the loading experience, not a separate concern.
 
 If a control isn't ready to do its job, don't show it as if it were. Options:
 
-- **Render the control disabled** until its handler is wired up. The user can see it but visibly cannot use it yet — that mismatch is honest.
-- **Defer the entire feature** behind a placeholder, and swap it in only when its code is loaded. This is the [Convert on Arrival](/patterns/convert_on_arrival/) pattern.
-- **Keep the form action working without JavaScript** so a submit during the gap still works — the page progressively enhances rather than depending on scripts for basic function.
+- **Render the control disabled** until its handler is wired up. The user can see it but visibly cannot use it yet — that mismatch is honest
+- **Defer the entire feature** behind a placeholder, and swap it in only when its code is loaded. This is the [Convert on Arrival](/patterns/convert_on_arrival/) pattern
+- **Keep the form action working without JavaScript** so a submit during the gap still works — the page progressively enhances rather than depending on scripts for basic function
 
 ### Make critical input paths cheap
 
@@ -49,18 +49,18 @@ The "see and do" gap is also one of the easiest performance problems to overlook
 
 ## Related Patterns
 
-- [Acknowledge Actions](/patterns/acknowledge_actions/) — what to do once interaction is ready.
-- [Convert on Arrival](/patterns/convert_on_arrival/) — staging interactivity progressively.
-- [Skeletal Designs](/patterns/skeletal_designs/) — placeholders for content that isn't ready yet.
+- [Acknowledge Actions](/patterns/acknowledge_actions/) — what to do once interaction is ready
+- [Convert on Arrival](/patterns/convert_on_arrival/) — staging interactivity progressively
+- [Skeletal Designs](/patterns/skeletal_designs/) — placeholders for content that isn't ready yet
 
 ## Technical Implementation
 
 ### Metrics to watch
 
-- **Interaction to Next Paint (INP)** — measures the latency of real user interactions. A page with bad INP looks fast and feels broken.
-- **Total Blocking Time (TBT)** — sums up the time the main thread is blocked by long tasks during load.
+- **Interaction to Next Paint (INP)** — measures the latency of real user interactions. A page with bad INP looks fast and feels broken
+- **Total Blocking Time (TBT)** — sums up the time the main thread is blocked by long tasks during load
 - **Long Tasks API** — surfaces individual tasks longer than 50ms that prevent the page from responding to input. ([Long Tasks spec](https://www.w3.org/TR/longtasks/))
-- **Time to Interactive (TTI)** — when the page has been visually ready and the main thread has stayed quiet long enough to handle input.
+- **Time to Interactive (TTI)** — when the page has been visually ready and the main thread has stayed quiet long enough to handle input
 
 Watch INP and TBT in real-user monitoring, not just lab tests — the lab can hide problems that real devices and real interaction patterns expose.
 
@@ -68,10 +68,10 @@ Watch INP and TBT in real-user monitoring, not just lab tests — the lab can hi
 
 The main thread is a single lane. While it's busy compiling a 400KB framework bundle or hydrating a thousand components, every user input is queued behind that work.
 
-- **Split work into smaller chunks** using `requestIdleCallback`, `scheduler.postTask`, or simple `setTimeout(0)` yields.
-- **Defer non-critical scripts** with `async`, `defer`, or dynamic imports gated by interaction.
-- **Avoid re-hydrating already-rendered server HTML** when possible — emerging patterns like resumability, islands, and selective hydration target exactly this cost.
-- **Audit third-party scripts.** Tag managers, analytics, A/B testing libraries and chat widgets are common sources of long tasks that block the page during the most visible part of load.
+- **Split work into smaller chunks** using `requestIdleCallback`, `scheduler.postTask`, or simple `setTimeout(0)` yields
+- **Defer non-critical scripts** with `async`, `defer`, or dynamic imports gated by interaction
+- **Avoid re-hydrating already-rendered server HTML** when possible — emerging patterns like resumability, islands, and selective hydration target exactly this cost
+- **Audit third-party scripts.** Tag managers, analytics, A/B testing libraries and chat widgets are common sources of long tasks that block the page during the most visible part of load
 
 ## Resources
 

--- a/src/patterns/see_and_do.md
+++ b/src/patterns/see_and_do.md
@@ -25,9 +25,37 @@ The user's experience is "I tapped the button and nothing happened." From their 
 
 Treat _interactivity_ as part of the loading experience, not a separate concern. The goal is to close the gap between "the user can see it" and "the user can use it" — ideally to zero.
 
-### 1. Measure the right thing
+### Don't render UI you can't yet operate
 
-Time-to-paint metrics like First Contentful Paint and Largest Contentful Paint don't tell you whether the page is responsive. The metrics that do:
+If a control isn't ready to do its job, don't show it as if it were. Options:
+
+- **Render the control disabled** until its handler is wired up. The user can see it but visibly cannot use it yet — that mismatch is honest.
+- **Defer the entire feature** behind a placeholder, and swap it in only when its code is loaded. This is the [Convert on Arrival](/patterns/convert_on_arrival/) pattern.
+- **Keep the form action working without JavaScript** so a submit during the gap still works — the page progressively enhances rather than depending on scripts for basic function.
+
+### Make critical input paths cheap
+
+Even when the rest of the page is busy, the path that handles "click the most important button on this view" should be reachable. If your hero CTA depends on a 200KB bundle that's still parsing, that's a design choice — usually the wrong one. Treat the most important interactions on each page as a budget: their handlers must be ready by the time the user can see them.
+
+### Watch the right thing
+
+Time-to-paint metrics don't tell you whether the page is responsive. Decisions need to be informed by interactivity metrics, not just paint metrics. Real-user monitoring (RUM) on responsiveness exposes problems that lab tests on fast hardware will hide.
+
+## Why This Matters
+
+A site that scores well on paint metrics but fails on interactivity feels worse than one that paints a bit slower but is responsive from the moment things appear. Users don't measure performance in milliseconds — they measure it in trust. Every dropped click chips away at that trust.
+
+The "see and do" gap is also one of the easiest performance problems to overlook because most automated checks don't surface it. Closing the gap means resisting the urge to ship visually-finished but functionally-incomplete UI.
+
+## Related Patterns
+
+- [Acknowledge Actions](/patterns/acknowledge_actions/) — what to do once interaction is ready.
+- [Convert on Arrival](/patterns/convert_on_arrival/) — staging interactivity progressively.
+- [Skeletal Designs](/patterns/skeletal_designs/) — placeholders for content that isn't ready yet.
+
+## Technical Implementation
+
+### Metrics to watch
 
 - **Interaction to Next Paint (INP)** — measures the latency of real user interactions. A page with bad INP looks fast and feels broken.
 - **Total Blocking Time (TBT)** — sums up the time the main thread is blocked by long tasks during load.
@@ -36,15 +64,7 @@ Time-to-paint metrics like First Contentful Paint and Largest Contentful Paint d
 
 Watch INP and TBT in real-user monitoring, not just lab tests — the lab can hide problems that real devices and real interaction patterns expose.
 
-### 2. Don't render UI you can't yet operate
-
-If a control isn't ready to do its job, don't show it as if it were. Options:
-
-- **Render the control disabled** until its handler is wired up. The user can see it but visibly cannot use it yet — that mismatch is honest.
-- **Defer the entire feature** behind a placeholder, and swap it in only when its code is loaded. This is the [Convert on Arrival](/patterns/convert_on_arrival/) pattern.
-- **Server-render the form action** so a submit during the gap still works — the page progressively enhances rather than depending on JS for basic function.
-
-### 3. Break up long tasks
+### Breaking up long tasks
 
 The main thread is a single lane. While it's busy compiling a 400KB framework bundle or hydrating a thousand components, every user input is queued behind that work.
 
@@ -52,22 +72,6 @@ The main thread is a single lane. While it's busy compiling a 400KB framework bu
 - **Defer non-critical scripts** with `async`, `defer`, or dynamic imports gated by interaction.
 - **Avoid re-hydrating already-rendered server HTML** when possible — emerging patterns like resumability, islands, and selective hydration target exactly this cost.
 - **Audit third-party scripts.** Tag managers, analytics, A/B testing libraries and chat widgets are common sources of long tasks that block the page during the most visible part of load.
-
-### 4. Make critical input paths cheap
-
-Even when the rest of the page is busy, the path that handles "click the most important button on this view" should be reachable. If your hero CTA depends on a 200KB JS bundle that's still parsing, that's a design choice — usually the wrong one.
-
-## Why This Matters
-
-A site that scores well on paint metrics but fails on interactivity feels worse than one that paints a bit slower but is responsive from the moment things appear. Users don't measure performance in milliseconds — they measure it in trust. Every dropped click chips away at that trust.
-
-The "see and do" gap is also one of the easiest performance problems to overlook because most automated checks don't surface it. Watching INP, splitting long tasks, and resisting the urge to ship visually-finished but functionally-incomplete UI keeps the experience honest.
-
-## Related Patterns
-
-- [Acknowledge Actions](/patterns/acknowledge_actions/) — what to do once interaction is ready.
-- [Convert on Arrival](/patterns/convert_on_arrival/) — staging interactivity progressively.
-- [Skeletal Designs](/patterns/skeletal_designs/) — placeholders for content that isn't ready yet.
 
 ## Resources
 

--- a/src/patterns/see_and_do.md
+++ b/src/patterns/see_and_do.md
@@ -21,6 +21,11 @@ Modern web apps frequently have a window — sometimes a few hundred millisecond
 
 The user's experience is "I tapped the button and nothing happened." From their perspective, the site is broken. From the dev tools' perspective, the page is "loaded" — the metric just doesn't match the experience.
 
+<figure>
+<figcaption>The user can see the page and the button (SEE), but a long task on the main thread is still blocking input — the click goes nowhere (DO).</figcaption>
+<img src="/assets/see_and_do_thumbnail.svg" width="400" alt="A page paint timeline showing alternating paint and long-task blocks; below it a circle marked SEE next to a button marked DO connected by a blue arrow, with a red exclamation mark indicating that JavaScript is blocking the click"/>
+</figure>
+
 ## Solution
 
 Treat _interactivity_ as part of the loading experience, not a separate concern. The goal is to close the gap between "the user can see it" and "the user can use it" — ideally to zero.

--- a/src/patterns/see_and_do.md
+++ b/src/patterns/see_and_do.md
@@ -24,7 +24,7 @@ The user's experience is "I tapped the button and nothing happened." From their 
 The user can see the page and the button (SEE), but a long task on the main thread is still blocking input — the click goes nowhere (DO).
 
 <figure>
-<img src="/assets/see_and_do_thumbnail.svg" width="400" alt="A page paint timeline showing alternating paint and long-task blocks; below it a circle marked SEE next to a button marked DO connected by a blue arrow, with a red exclamation mark indicating that JavaScript is blocking the click"/>
+<img src="/assets/see_and_do_thumbnail.svg" width="460" alt="A page paint timeline showing alternating paint and long-task blocks; below it a circle marked SEE next to a button marked DO connected by a blue arrow, with a red exclamation mark indicating that JavaScript is blocking the click"/>
 <figcaption>Visible should mean usable</figcaption>
 </figure>
 

--- a/src/patterns/see_and_do.md
+++ b/src/patterns/see_and_do.md
@@ -5,6 +5,12 @@ tags: pattern
 thumbnail: /assets/see_and_do_thumbnail.svg
 og_image: /assets/speed_patterns_og_image.jpg
 order: 10
+date: 2017-12-27
+authors:
+    - name: Joseph Gannon
+      url: https://www.linkedin.com/in/environmentalux/
+    - name: Sergey Chernyshev
+      url: https://www.sergeychernyshev.com/
 ---
 
 When a user can see a button, they assume they can press it. When they can read a form field, they assume they can type into it. The mental model is simple: visible means usable. The web routinely violates this assumption — JavaScript is still parsing, hydrating, or executing long tasks during the seconds after first paint, and the page sits there looking interactive while not actually responding to input.


### PR DESCRIPTION
## Summary
- Adds a new pattern article on closing the gap between when content becomes visible and when the page can actually respond to interaction.
- Covers the right metrics (INP, TBT, Long Tasks, TTI), avoiding rendering UI you can't yet operate, breaking up long tasks, and protecting critical interaction paths.
- Includes a simple SVG thumbnail and reuses the site-wide OG image.

Closes #8

## Test plan
- [ ] Run `npm run start` and verify the article renders at `/patterns/see_and_do/`
- [ ] Confirm the new pattern appears in the homepage list with thumbnail
- [ ] Confirm the new pattern shows up in the side nav

🤖 Generated with [Claude Code](https://claude.com/claude-code)
