### PR TITLE
Style code blocks: build-time colorization, border, copy button

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,9 +1,11 @@
 const markdownIt = require("markdown-it");
+const syntaxHighlight = require("@11ty/eleventy-plugin-syntaxhighlight");
 
 module.exports = function (eleventyConfig) {
   // Set custom directories for input, output, includes, and data
   eleventyConfig.addPassthroughCopy("src/style.css");
   eleventyConfig.addPassthroughCopy("src/assets/**");
+  eleventyConfig.addPlugin(syntaxHighlight);
   eleventyConfig.setFrontMatterParsingOptions({
     excerpt: true,
     // Optional, default is "---"

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@11ty/eleventy": "^1.0.0",
+        "@11ty/eleventy-plugin-syntaxhighlight": "^5.0.2",
         "markdown-it": "^14.1.0"
       }
     },
@@ -61,6 +62,19 @@
       },
       "engines": {
         "node": ">=12"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/11ty"
+      }
+    },
+    "node_modules/@11ty/eleventy-plugin-syntaxhighlight": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@11ty/eleventy-plugin-syntaxhighlight/-/eleventy-plugin-syntaxhighlight-5.0.2.tgz",
+      "integrity": "sha512-T6xVVRDJuHlrFMHbUiZkHjj5o1IlLzZW+1IL9eUsyXFU7rY2ztcYhZew/64vmceFFpQwzuSfxQOXxTJYmKkQ+A==",
+      "license": "MIT",
+      "dependencies": {
+        "prismjs": "^1.30.0"
       },
       "funding": {
         "type": "opencollective",
@@ -2266,6 +2280,15 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/prismjs": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
+      "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/promise": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "homepage": "https://github.com/AlexanderChernyshev/speed-patterns#readme",
   "dependencies": {
     "@11ty/eleventy": "^1.0.0",
+    "@11ty/eleventy-plugin-syntaxhighlight": "^5.0.2",
     "markdown-it": "^14.1.0"
   }
 }

--- a/src/_includes/layout.njk
+++ b/src/_includes/layout.njk
@@ -38,6 +38,42 @@
                 })
         </script>
 
+        <script>
+            // Wires the click handler for the copy button. Token coloring is
+            // produced at build time; this script does no syntax highlighting.
+            document.querySelectorAll('pre[class*="language-"]').forEach(function (pre) {
+                var btn = document.createElement("button");
+                btn.type = "button";
+                btn.className = "copy-btn";
+                btn.textContent = "Copy";
+                btn.setAttribute("aria-label", "Copy code to clipboard");
+                btn.addEventListener("click", function () {
+                    var code = pre.querySelector("code");
+                    var text = code ? code.innerText : pre.innerText;
+                    var done = function () {
+                        btn.textContent = "Copied!";
+                        btn.classList.add("copied");
+                        setTimeout(function () {
+                            btn.textContent = "Copy";
+                            btn.classList.remove("copied");
+                        }, 1500);
+                    };
+                    if (navigator.clipboard && navigator.clipboard.writeText) {
+                        navigator.clipboard.writeText(text).then(done);
+                    } else {
+                        var ta = document.createElement("textarea");
+                        ta.value = text;
+                        document.body.appendChild(ta);
+                        ta.select();
+                        try { document.execCommand("copy"); } catch (e) {}
+                        document.body.removeChild(ta);
+                        done();
+                    }
+                });
+                pre.appendChild(btn);
+            });
+        </script>
+
         <nav class="mobile-hidden">
             <ul>
                 <li class="home-link">

--- a/src/style.css
+++ b/src/style.css
@@ -147,6 +147,147 @@ pre {
     text-wrap: pretty;
 }
 
+/* Code blocks */
+pre[class*="language-"] {
+    position: relative;
+    background-color: #2D3866;
+    color: #fff4de;
+    border: solid 1px #1c2347;
+    border-left: solid 0.5em #4F63B3;
+    border-radius: 6px;
+    padding: 1em 1.25em;
+    margin: 1.5em 0;
+    overflow-x: auto;
+    font-family: "Menlo", "Consolas", "Monaco", "Liberation Mono", monospace;
+    font-size: 0.9em;
+    line-height: 1.5;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.08);
+}
+
+pre[class*="language-"] code {
+    font-family: inherit;
+    color: inherit;
+    background: none;
+    padding: 0;
+}
+
+:not(pre) > code[class*="language-"],
+:not(pre) > code {
+    background-color: #f0e6d3;
+    color: #2d2a26;
+    padding: 0.1em 0.35em;
+    border-radius: 3px;
+    font-family: "Menlo", "Consolas", "Monaco", "Liberation Mono", monospace;
+    font-size: 0.92em;
+}
+
+/* Prism tokens — colorization is pure CSS; markup is generated at build time */
+.token.comment,
+.token.prolog,
+.token.doctype,
+.token.cdata {
+    color: #8a93b8;
+    font-style: italic;
+}
+
+.token.punctuation {
+    color: #a8b0d4;
+}
+
+.token.namespace {
+    opacity: 0.7;
+}
+
+.token.property,
+.token.boolean,
+.token.number,
+.token.constant,
+.token.symbol,
+.token.deleted {
+    color: #ffb0a0;
+}
+
+.token.selector,
+.token.attr-name,
+.token.string,
+.token.char,
+.token.builtin,
+.token.inserted {
+    color: #b8e8b0;
+}
+
+.token.operator,
+.token.entity,
+.token.url,
+.language-css .token.string,
+.style .token.string {
+    color: #ffd680;
+}
+
+.token.atrule,
+.token.attr-value,
+.token.keyword {
+    color: #ffd680;
+}
+
+.token.function,
+.token.class-name {
+    color: #c5b3ff;
+}
+
+.token.tag {
+    color: #f59574;
+}
+
+.token.regex,
+.token.important,
+.token.variable {
+    color: #ffd680;
+}
+
+.token.important,
+.token.bold {
+    font-weight: bold;
+}
+
+.token.italic {
+    font-style: italic;
+}
+
+.token.entity {
+    cursor: help;
+}
+
+/* Copy button */
+.copy-btn {
+    position: absolute;
+    top: 0.5em;
+    right: 0.5em;
+    padding: 0.35em 0.7em;
+    background-color: rgba(255, 244, 222, 0.12);
+    color: #fff4de;
+    border: solid 1px rgba(255, 244, 222, 0.3);
+    border-radius: 4px;
+    font-family: inherit;
+    font-size: 0.8em;
+    line-height: 1;
+    cursor: pointer;
+    transition: background-color 0.15s, border-color 0.15s, color 0.15s;
+}
+
+.copy-btn:hover,
+.copy-btn:focus-visible {
+    background-color: rgba(255, 244, 222, 0.22);
+    border-color: rgba(255, 244, 222, 0.5);
+    outline: none;
+}
+
+.copy-btn.copied {
+    background-color: #4F63B3;
+    border-color: #4F63B3;
+    color: #fff4de;
+}
+
 @media screen and (min-width: 75em) {
 
     .mobile-hidden {


### PR DESCRIPTION
## Summary
- Adds build-time syntax highlighting via [`@11ty/eleventy-plugin-syntaxhighlight`](https://github.com/11ty/eleventy-plugin-syntaxhighlight) (uses Prism at build time — no runtime JS performs coloring).
- Themes Prism token classes in `style.css` to match the site's navy/cream palette, with a colored left-border accent.
- Adds a small copy button in the corner of each code block. Only the click handler is JS; the colorization stays pure CSS.
- Inline `code` (not in a `pre`) gets a subtle beige pill style.

## Test plan
- [ ] Run `npm run start`, visit `/patterns/immutable_layout/` and confirm the HTML code block shows token colors and a `Copy` button
- [ ] Click `Copy` and confirm the snippet is on the clipboard and the button briefly says `Copied!`
- [ ] After the pending pattern PRs merge, verify the new articles' code samples (HTML, JS, CSS) are also colorized

🤖 Generated with [Claude Code](https://claude.com/claude-code)
