### PR TITLE
Add AGENTS.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-pattern.md
+++ b/.github/ISSUE_TEMPLATE/new-pattern.md
@@ -1,7 +1,7 @@
 ---
 name: New Pattern
 about: Propose a new speed-design pattern for this site
-title: 'New Pattern: <name of the pattern>'
+title: "New Pattern: <name of the pattern>"
 labels: New Pattern
 ---
 
@@ -11,12 +11,10 @@ where they help. Concentrate on the user-experience challenge and the design
 solution; technical detail is supporting material.
 -->
 
-
-
 ## Existing blog posts, articles, videos
 
-- 
+-
 
 ## Links to successful implementations
 
-- 
+-

--- a/.github/ISSUE_TEMPLATE/new-pattern.md
+++ b/.github/ISSUE_TEMPLATE/new-pattern.md
@@ -1,0 +1,22 @@
+---
+name: New Pattern
+about: Propose a new speed-design pattern for this site
+title: 'New Pattern: <name of the pattern>'
+labels: New Pattern
+---
+
+<!--
+Describe the pattern. Include illustrations, screen grabs, or animated GIFs
+where they help. Concentrate on the user-experience challenge and the design
+solution; technical detail is supporting material.
+-->
+
+
+
+## Existing blog posts, articles, videos
+
+- 
+
+## Links to successful implementations
+
+- 

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,5 @@
+_site/
+node_modules/
+package-lock.json
+src/assets/
+src/**/*.njk

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,10 @@
+{
+  "overrides": [
+    {
+      "files": "*.css",
+      "options": {
+        "tabWidth": 4
+      }
+    }
+  ]
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,13 @@ Common commands:
 
 - `npm run start` — local dev server with live reload
 - `npm run build` — one-shot build into `_site/`
+- `npm run format` — run [Prettier](https://prettier.io/) across the project
+
+## Formatting
+
+Run `npm run format` after making any changes to project files. Prettier is configured to format Markdown, CSS, JS, JSON and YAML; Nunjucks templates, SVG assets, the build output and `package-lock.json` are excluded via `.prettierignore`.
+
+This is a hard rule — every commit on this branch should be formatted. If you make a change to a pattern article, the issue template, AGENTS.md, CONTRIBUTING.md, the stylesheet, the Eleventy config or any other Prettier-supported file, run `npm run format` before staging.
 
 ## Repo layout
 
@@ -109,6 +116,7 @@ Always tag fenced code blocks with a language (`html`, `css`, `js`, etc.) so Pri
 
 - Branch off `master`; one feature per branch
 - One pattern = one PR. Bundle code-block, asset and config changes into their own PRs (don't co-mingle with article content)
+- Run `npm run format` before staging — see the **Formatting** section above
 - Default base branch: `master`
 - The repo has two remotes: `origin` (Speed-Patterns/speed-patterns, the canonical one) and `alex`. Push to `origin` unless told otherwise
 - Don't force-push without explicit user approval; if rebasing a shared branch is needed, use `--force-with-lease`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,7 +84,15 @@ Technical detail belongs at the end of the article. Lead with UX/design content;
 ### Assets
 
 - Images live in [src/assets/](src/assets/) and are passthrough-copied by Eleventy
-- Prefer SVG for diagrammatic thumbnails — the existing palette is warm beige (`#fff4de`, `#f0e6d3`) with brown / navy accents (`#a98c5a`, `#5a4a2e`, `#2D3866`, `#4F63B3`)
+- Prefer SVG for diagrammatic thumbnails and inline diagrams. Follow the visual language of the canonical example, [src/assets/skeletal_design_perception_time_diagram.svg](src/assets/skeletal_design_perception_time_diagram.svg):
+  - White background (`#fff`)
+  - Primary fills: yellow `#fd0` and orange `#ffa400` for content / state boxes
+  - Zone tints used at low opacity (~0.1–0.2): green `#00f13e` for the "with pattern" / good zone and red `#f11300` for the "without pattern" / bad zone
+  - Accent line color: blue `#0085f1` (e.g. for time / progression arrows)
+  - Borders, arrows and labels: black `#000`
+  - Typography: sans-serif (Arial / system stack)
+  - Place a low-opacity `SPEEDPATTERNS.COM` wordmark in a corner for diagrams that may be reused outside the site
+- The site chrome (header, nav, sidebar) uses a separate warm-beige palette (`#fff4de`, `#f0e6d3`, `#a98c5a`, `#2D3866`, `#4F63B3`) — that palette is for the page itself, not for in-article diagrams
 - For new patterns, the site-wide [src/assets/speed_patterns_og_image.jpg](src/assets/speed_patterns_og_image.jpg) is an acceptable temporary `og_image` until a per-pattern one is designed
 
 ## Code blocks

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,12 +1,14 @@
 # AGENTS.md
 
-Guidance for AI coding agents (Claude Code, Cursor, etc.) working in this repo.
+Guidance for AI coding agents working in this repo.
 
 ## Project
 
 **Speed Patterns** — a collection of product / UX / visual design patterns for fast web sites, published at <https://www.speedpatterns.com/>.
 
-The site is aimed at product managers, designers and front-end developers planning speed-aware experiences from inception. Articles concentrate on **user-experience challenges and solutions**, not implementation specifics. Technical detail is supporting material; if a pattern can only be understood through code, it's probably the wrong altitude for this site.
+The site is aimed at product managers, designers and front-end developers planning speed-aware experiences from inception. Articles concentrate on **user-experience challenges and solutions**, not implementation specifics.
+
+Technical detail is supporting material; if a pattern can only be understood through code, it's probably the wrong altitude for this site. If more technical details are written up in an article somewhere, link to it instead, no need to be an authoritative source of technical information.
 
 ## Build
 
@@ -90,7 +92,7 @@ Technical detail belongs at the end of the article. Lead with UX/design content;
 Code samples are highlighted at build time by Prism (via the Eleventy plugin) and themed by CSS in [src/style.css](src/style.css). Each block:
 
 - Has a colored navy background with a brand-blue left-border accent
-- Includes a "Copy" button injected by a small script in [src/_includes/layout.njk](src/_includes/layout.njk)
+- Includes a "Copy" button injected by a small script in [src/\_includes/layout.njk](src/_includes/layout.njk)
 - Token coloring is **CSS only** — never add a runtime JS syntax highlighter
 
 Always tag fenced code blocks with a language (`html`, `css`, `js`, etc.) so Prism can tokenize them.
@@ -109,7 +111,3 @@ Always tag fenced code blocks with a language (`html`, `css`, `js`, etc.) so Pri
 - Don't add runtime syntax highlighters or any other library that does coloring at page load — Prism at build time is the only colorization mechanism
 - Don't put trailing periods on list items
 - Don't introduce CLAUDE.md or other agent-config files without checking first; this AGENTS.md is the canonical agent guidance
-
-## Open questions / future work
-
-_(Section left for the maintainer to fill in.)_

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,115 @@
+# AGENTS.md
+
+Guidance for AI coding agents (Claude Code, Cursor, etc.) working in this repo.
+
+## Project
+
+**Speed Patterns** — a collection of product / UX / visual design patterns for fast web sites, published at <https://www.speedpatterns.com/>.
+
+The site is aimed at product managers, designers and front-end developers planning speed-aware experiences from inception. Articles concentrate on **user-experience challenges and solutions**, not implementation specifics. Technical detail is supporting material; if a pattern can only be understood through code, it's probably the wrong altitude for this site.
+
+## Build
+
+- Static site generator: [Eleventy 1.0](https://www.11ty.dev/) (config in [.eleventy.js](.eleventy.js))
+- Markdown: `markdown-it` with `html: true`
+- Excerpts: split on `<!-- excerpt -->` (used by the homepage card list)
+- Syntax highlighting: [`@11ty/eleventy-plugin-syntaxhighlight`](https://github.com/11ty/eleventy-plugin-syntaxhighlight) (Prism, build-time only — no runtime JS performs token coloring)
+
+Common commands:
+
+- `npm run start` — local dev server with live reload
+- `npm run build` — one-shot build into `_site/`
+
+## Repo layout
+
+```
+.eleventy.js              Eleventy config (plugins, collections, filters)
+src/
+  index.njk               Homepage (lists patterns by `order`)
+  patterns/*.md           One file per pattern (this is where new content lives)
+  _includes/
+    layout.njk            Base HTML layout (header, nav, sidebar, copy-button JS)
+    article.njk           Per-article wrapper (title + OG meta)
+  assets/                 Images, SVGs, og_image files, thumbnails
+  style.css               All site styles (single file)
+_site/                    Build output (gitignored)
+CONTRIBUTING.md           Public contributor guide (how new patterns are proposed)
+```
+
+## Pattern article conventions
+
+Each pattern article in [src/patterns/](src/patterns/) is a Markdown file with frontmatter:
+
+```yaml
+---
+layout: article.njk
+title: <Title Case Pattern Name>
+tags: pattern
+thumbnail: /assets/<pattern>_thumbnail.svg
+og_image: /assets/<pattern>_og_image.jpg
+order: <integer; controls homepage position>
+---
+```
+
+- The `tags: pattern` value adds the article to the `pattern` collection (used by the side nav and the ordered homepage list)
+- `order` is the homepage sort key; existing values are 1 (Fast Start), 2 (Immutable Layout), 3 (Skeletal Designs); new patterns continue from there
+- `thumbnail` shows on the homepage card; `og_image` powers the social-share preview
+
+### Body structure
+
+A short opening paragraph that frames the user-experience problem, followed by `<!-- excerpt -->`, followed by the rest of the article. The excerpt feeds the homepage card.
+
+Preferred section order:
+
+1. Intro paragraph + `<!-- excerpt -->` separator
+2. **The Problem** — the UX failure mode the pattern fixes
+3. **Solution** — the design / UX approach (no code yet)
+4. **Why This Works** or **Why This Matters** — the principle behind it
+5. **Guidelines** — UX-level dos and don'ts
+6. **Related Patterns** — links to other patterns on the site
+7. **Technical Implementation** — code samples, APIs, library names (kept at the bottom on purpose)
+8. **Resources** — outbound links to further reading
+
+Technical detail belongs at the end of the article. Lead with UX/design content; introduce APIs and code only after the conceptual story is told.
+
+### Content style
+
+- Use sentence-case prose; avoid jargon without context
+- Use the existing patterns in [src/patterns/](src/patterns/) as a tone reference
+- **List items don't end with a period.** Internal sentences inside a multi-sentence bullet keep their internal periods, but the trailing period is dropped. Question marks, parenthetical closers and quoted speech are preserved
+- Cross-link to other patterns with relative URLs like `/patterns/skeletal_designs/`
+
+### Assets
+
+- Images live in [src/assets/](src/assets/) and are passthrough-copied by Eleventy
+- Prefer SVG for diagrammatic thumbnails — the existing palette is warm beige (`#fff4de`, `#f0e6d3`) with brown / navy accents (`#a98c5a`, `#5a4a2e`, `#2D3866`, `#4F63B3`)
+- For new patterns, the site-wide [src/assets/speed_patterns_og_image.jpg](src/assets/speed_patterns_og_image.jpg) is an acceptable temporary `og_image` until a per-pattern one is designed
+
+## Code blocks
+
+Code samples are highlighted at build time by Prism (via the Eleventy plugin) and themed by CSS in [src/style.css](src/style.css). Each block:
+
+- Has a colored navy background with a brand-blue left-border accent
+- Includes a "Copy" button injected by a small script in [src/_includes/layout.njk](src/_includes/layout.njk)
+- Token coloring is **CSS only** — never add a runtime JS syntax highlighter
+
+Always tag fenced code blocks with a language (`html`, `css`, `js`, etc.) so Prism can tokenize them.
+
+## Workflow
+
+- Branch off `master`; one feature per branch
+- One pattern = one PR. Bundle code-block, asset and config changes into their own PRs (don't co-mingle with article content)
+- Default base branch: `master`
+- The repo has two remotes: `origin` (Speed-Patterns/speed-patterns, the canonical one) and `alex`. Push to `origin` unless told otherwise
+- Don't force-push without explicit user approval; if rebasing a shared branch is needed, use `--force-with-lease`
+
+## Things to avoid
+
+- Don't run `npm audit fix` or upgrade dependencies as part of unrelated work — leave dependency PRs to Dependabot or a focused upgrade PR
+- Don't add runtime syntax highlighters or any other library that does coloring at page load — Prism at build time is the only colorization mechanism
+- Don't put trailing periods on list items
+- Don't introduce CLAUDE.md or other agent-config files without checking first; this AGENTS.md is the canonical agent guidance
+
+## Open questions / future work
+
+_(Section left for the maintainer to fill in.)_

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,7 +99,7 @@ Technical detail belongs at the end of the article. Lead with UX/design content;
   - Borders, arrows and labels: black `#000`
   - Typography: sans-serif (Arial / system stack)
   - Place a low-opacity `SPEEDPATTERNS.COM` wordmark in a corner for diagrams that may be reused outside the site
-- The site chrome (header, nav, sidebar) uses a separate warm-beige palette (`#fff4de`, `#f0e6d3`, `#a98c5a`, `#2D3866`, `#4F63B3`) — that palette is for the page itself, not for in-article diagrams
+- The site chrome (header, nav, sidebar) uses a separate warm-beige palette (`#fff4de`, `#f0e6d3`, `#a98c5a`, `#2d3866`, `#4f63b3`) — that palette is for the page itself, not for in-article diagrams
 - For new patterns, the site-wide [src/assets/speed_patterns_og_image.jpg](src/assets/speed_patterns_og_image.jpg) is an acceptable temporary `og_image` until a per-pattern one is designed
 
 ## Code blocks

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,30 +1,36 @@
 # How to Contribute
 
 ## 1. Propose new pattern
+
 To make sure we cover as many patterns as possible to help development of fast web sites (as opposed to discovering issues too late in the game), you are encouraged to submit new patterns to the project.
 
 [Submit a new issue](https://github.com/Speed-Patterns/speed-patterns/issues/new?body=...%20describe%20the%20pattern%2C%20include%20illustrations%20...%0D%0A%0D%0A%23%23%20WebPageTest%20report%20for%20pages%20following%20and%20not%20following%20the%20pattern%3A%0D%0A%2A%20Success%3A%20http%3A%2F%2Fwww.webpagetest.org%2Fresult%2F...%0D%0A%2A%20Failure%3A%20http%3A%2F%2Fwww.webpagetest.org%2Fresult%2F...%0D%0A%0D%0A%23%23%20Existing%20blog%20posts%2C%20articles%2C%20videos%0D%0A%2A%20%0D%0A%0D%0A%23%23%20Links%20to%20successful%20implementations%0D%0A%2A&title=New+Pattern%3A+...name+of+the+pattern...&labels=New+Pattern) and describe a high level pattern to start the discussion on what is the best approach to document a pattern and gather feedback from maintainers and other members.
 To help others get a headstart in understanding the pattern, you can collect some of the following supporting materials:
-* Links to existing blog posts, articles, videos describing the issues or solutions to the problem
-* Links to web sites that already successfully implement the pattern
-* Illustrations of the problems in the form of screen grabs or videos / animated GIFs showing successes and failures to implement the pattern
-* Technical documentation helping identify the properly followed pattern, e.g. waterfall charts and filmstrips. Links to [WebPageTest](http://www.webpagetest.org/) test results help a lot.
+
+- Links to existing blog posts, articles, videos describing the issues or solutions to the problem
+- Links to web sites that already successfully implement the pattern
+- Illustrations of the problems in the form of screen grabs or videos / animated GIFs showing successes and failures to implement the pattern
+- Technical documentation helping identify the properly followed pattern, e.g. waterfall charts and filmstrips.
 
 You can mark submissions that are in early stages of definition and need more active help using [`draft`](https://github.com/Speed-Patterns/speed-patterns/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+label%3A%22New+Pattern%22+label%3Adraft) label.
 
 ### License
+
 By contributing to this project, you agree that your work will be shared under [Creative Commons Attribution 4.0 International Lincense](https://creativecommons.org/licenses/by/4.0/) [![License: CC BY 4.0](https://licensebuttons.net/l/by/4.0/80x15.png)](https://creativecommons.org/licenses/by/4.0/)
 
 Please help us attribute your work properly by adding your name to [CONTRIBUTORS](https://github.com/Speed-Patterns/speed-patterns/blob/master/CONTRIBUTORS.md) file
 
 ## 2. Help formulating new patterns
+
 It takes some good conversation to describe a design pattern to make sure it is well established and has legs, please help by reviewing and leaving comments on [existing submissions](https://github.com/Speed-Patterns/speed-patterns/issues) and [pull requests](https://github.com/Speed-Patterns/speed-patterns/pulls).
 
 ## 3. Add new pattern page
+
 When it is clear that the pattern is well established and you collected feedback from other members and maintainers, create a new pattern file in [`/_patterns/`](https://github.com/Speed-Patterns/speed-patterns/tree/master/_patterns) folder and supporting assets in [`/assets/`](https://github.com/Speed-Patterns/speed-patterns/tree/master/assets) folder and open a pull request.
 Please include a link to existing pattern issues to help maintainers get context of the previous conversation.
 
 ## 4. Celebrate and share
+
 Patterns and best practices are only good if the are followed.
 
 Start by adopting them and celebrating them in your development and share them with your collegues and wider public.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 
 To make sure we cover as many patterns as possible to help development of fast web sites (as opposed to discovering issues too late in the game), you are encouraged to submit new patterns to the project.
 
-[Submit a new issue](https://github.com/Speed-Patterns/speed-patterns/issues/new?body=...%20describe%20the%20pattern%2C%20include%20illustrations%20...%0D%0A%0D%0A%23%23%20WebPageTest%20report%20for%20pages%20following%20and%20not%20following%20the%20pattern%3A%0D%0A%2A%20Success%3A%20http%3A%2F%2Fwww.webpagetest.org%2Fresult%2F...%0D%0A%2A%20Failure%3A%20http%3A%2F%2Fwww.webpagetest.org%2Fresult%2F...%0D%0A%0D%0A%23%23%20Existing%20blog%20posts%2C%20articles%2C%20videos%0D%0A%2A%20%0D%0A%0D%0A%23%23%20Links%20to%20successful%20implementations%0D%0A%2A&title=New+Pattern%3A+...name+of+the+pattern...&labels=New+Pattern) and describe a high level pattern to start the discussion on what is the best approach to document a pattern and gather feedback from maintainers and other members.
+[Submit a new issue](https://github.com/Speed-Patterns/speed-patterns/issues/new?template=new-pattern.md) using the **New Pattern** template and describe a high level pattern to start the discussion on what is the best approach to document a pattern and gather feedback from maintainers and other members.
 To help others get a headstart in understanding the pattern, you can collect some of the following supporting materials:
 
 - Links to existing blog posts, articles, videos describing the issues or solutions to the problem

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,5 +1,5 @@
 # Contributors
 
-* [Sergey Chernyshev](https://www.sergeychernyshev.com/)
+- [Sergey Chernyshev](https://www.sergeychernyshev.com/)
 
 ... [add your name here](https://github.com/Speed-Patterns/speed-patterns/blob/master/CONTRIBUTING.md) ...

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Speed Patterns
+
 A collection of design patterns for fast web sites published on http://www.speedpatterns.com/
 
 The goal of this project is to collect **product / UX / visual design patterns for creating fast web sites** and intended to help product managers, web designers and front-end developers plan speedy experiences from project inception or help articulate the improvements when performance issues are identified later down the road.
@@ -8,5 +9,6 @@ We concentrate on describing user experience challenges and solutions, but also 
 High level technical solution might also be provided, but linking to outside technical resources and industry articles is encouraged as we strive to define stable long-term patterns rooted in user psychology and web fundamentals and not on specific solutions that vary too much based on technology stacks and latest developments in browser technology.
 
 # Contributing
+
 Project is open for everybody to contribute. Please help us cover as many use-cases and known solutions to speed design problems as possible.
 See [Contributing Guide](https://github.com/Speed-Patterns/speed-patterns/tree/master/CONTRIBUTING.md) to see how you can help.

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,9 @@
         "@11ty/eleventy": "^1.0.0",
         "@11ty/eleventy-plugin-syntaxhighlight": "^5.0.2",
         "markdown-it": "^14.1.0"
+      },
+      "devDependencies": {
+        "prettier": "^3.8.3"
       }
     },
     "node_modules/@11ty/dependency-tree": {
@@ -2267,6 +2270,22 @@
       "engines": {
         "node": ">=0.4",
         "npm": ">=1.0.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/pretty": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "start": "npx @11ty/eleventy --serve",
-    "build": "npx @11ty/eleventy"
+    "build": "npx @11ty/eleventy",
+    "format": "prettier --write ."
   },
   "repository": {
     "type": "git",
@@ -22,5 +23,8 @@
     "@11ty/eleventy": "^1.0.0",
     "@11ty/eleventy-plugin-syntaxhighlight": "^5.0.2",
     "markdown-it": "^14.1.0"
+  },
+  "devDependencies": {
+    "prettier": "^3.8.3"
   }
 }

--- a/src/style.css
+++ b/src/style.css
@@ -15,7 +15,6 @@
 }
 
 @media screen and (max-width: 110em) {
-
     .textimagepair {
         flex-direction: column;
     }
@@ -24,7 +23,6 @@
         margin-left: auto;
         margin-right: auto;
     }
-
 }
 
 .callout {
@@ -99,7 +97,7 @@ nav li {
 header {
     display: flex;
     align-items: center;
-    background-color: #2D3866;
+    background-color: #2d3866;
     padding: 1em;
     font-size: 2em;
     font-family: Arial, Helvetica, sans-serif;
@@ -118,11 +116,11 @@ header a:visited {
 }
 
 a {
-    color: #4F63B3;
+    color: #4f63b3;
 }
 
 a:visited {
-    color: #2D3866;
+    color: #2d3866;
 }
 
 main {
@@ -150,10 +148,10 @@ pre {
 /* Code blocks */
 pre[class*="language-"] {
     position: relative;
-    background-color: #2D3866;
+    background-color: #2d3866;
     color: #fff4de;
     border: solid 1px #1c2347;
-    border-left: solid 0.5em #4F63B3;
+    border-left: solid 0.5em #4f63b3;
     border-radius: 6px;
     padding: 1em 1.25em;
     margin: 1.5em 0;
@@ -272,7 +270,10 @@ pre[class*="language-"] code {
     font-size: 0.8em;
     line-height: 1;
     cursor: pointer;
-    transition: background-color 0.15s, border-color 0.15s, color 0.15s;
+    transition:
+        background-color 0.15s,
+        border-color 0.15s,
+        color 0.15s;
 }
 
 .copy-btn:hover,
@@ -283,13 +284,12 @@ pre[class*="language-"] code {
 }
 
 .copy-btn.copied {
-    background-color: #4F63B3;
-    border-color: #4F63B3;
+    background-color: #4f63b3;
+    border-color: #4f63b3;
     color: #fff4de;
 }
 
 @media screen and (min-width: 75em) {
-
     .mobile-hidden {
         display: block;
     }
@@ -337,5 +337,4 @@ pre[class*="language-"] code {
     .burger {
         display: none;
     }
-
 }


### PR DESCRIPTION
## Summary
- Adds `AGENTS.md` at the repo root as a starting framework for AI coding-agent guidance (Claude Code, Cursor, etc.)
- Covers project purpose, build pipeline (Eleventy + markdown-it + Prism), repo layout, pattern article conventions (frontmatter, section order, no trailing periods on list items), code-block colorization rules, and workflow
- Leaves an "Open questions / future work" stub at the bottom for the maintainer to extend

## Test plan
- [ ] Open `AGENTS.md` and confirm it accurately reflects the repo's current structure and conventions
- [ ] Add any project-specific details that should be captured before merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)
