### PR TITLE
Center figcaption and image horizontally inside figure

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -33,6 +33,21 @@
     border-radius: 5px;
 }
 
+figure {
+    text-align: center;
+}
+
+figure img {
+    display: block;
+    max-width: 100%;
+    height: auto;
+    margin: 0 auto;
+}
+
+figure figcaption {
+    text-align: center;
+}
+
 header span {
     display: flex;
     align-items: center;


### PR DESCRIPTION
## Summary
- Centers `<img>` horizontally inside its `<figure>` container (`display: block; margin: 0 auto`)
- Centers `<figcaption>` text horizontally relative to the image
- Adds `max-width: 100%; height: auto` to keep figure images responsive
- Site-wide change in `src/style.css` — applies to existing articles (`fast_start`, `immutable_layout`, `skeletal_designs`) and to every pending pattern PR once they merge

## Test plan
- [ ] Run `npm run start`, visit each article and confirm images and captions are centered
- [ ] Confirm no regression on `<section class="textimagepair">` blocks in `skeletal_designs.md` (those use a flex layout, not figure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
