### PR TITLE
Add Progress Indication pattern

### DIFF
--- a/src/assets/progress_indication_thumbnail.svg
+++ b/src/assets/progress_indication_thumbnail.svg
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 520 360" width="520" height="360" font-family="Arial, sans-serif">
+  <title>Progress Indication</title>
+  <desc>A ranked list of four progress-indication options. From top: a determinate progress bar labeled "real progress (preferred)"; a skeleton layout labeled "structural placeholder"; a button with the label "Submitting…" labeled "action acknowledgment"; a circular spinner with a dashed red border labeled "spinner (last resort)".</desc>
+
+  <rect width="520" height="360" fill="#fff"/>
+
+  <text x="260" y="26" text-anchor="middle" font-size="14" fill="#000">Four ways to indicate progress</text>
+
+  <!-- 1. Real progress (preferred) -->
+  <g transform="translate(40,50)">
+    <rect x="0" y="0" width="440" height="56" fill="#00f13e" fill-opacity="0.12" stroke="#000"/>
+    <text x="14" y="20" font-size="12" fill="#000">1. Real progress (preferred)</text>
+    <!-- progress bar -->
+    <rect x="14" y="30" width="280" height="14" fill="#fff" stroke="#000"/>
+    <rect x="14" y="30" width="180" height="14" fill="#0085f1" opacity="0.7"/>
+    <text x="304" y="42" font-size="11" fill="#000">Uploading 3 of 8 — 64%</text>
+  </g>
+
+  <!-- 2. Structural placeholder -->
+  <g transform="translate(40,118)">
+    <rect x="0" y="0" width="440" height="64" fill="#00f13e" fill-opacity="0.08" stroke="#000"/>
+    <text x="14" y="20" font-size="12" fill="#000">2. Structural placeholder (Skeletal Designs)</text>
+    <!-- skeleton lines -->
+    <rect x="14" y="30" width="160" height="10" fill="#000" opacity="0.4"/>
+    <rect x="14" y="44" width="120" height="6" fill="#000" opacity="0.25"/>
+    <rect x="184" y="30" width="240" height="22" fill="#000" opacity="0.12" stroke="#000" stroke-opacity="0.3"/>
+  </g>
+
+  <!-- 3. Action acknowledgment -->
+  <g transform="translate(40,194)">
+    <rect x="0" y="0" width="440" height="58" fill="#00f13e" fill-opacity="0.06" stroke="#000"/>
+    <text x="14" y="20" font-size="12" fill="#000">3. Action acknowledgment</text>
+    <!-- button -->
+    <rect x="14" y="28" width="130" height="22" fill="#fff" stroke="#000" stroke-dasharray="3 2"/>
+    <text x="79" y="44" text-anchor="middle" font-size="11" fill="#000">Submitting…</text>
+    <!-- inline indicator dots -->
+    <circle cx="156" cy="39" r="2.5" fill="#000" opacity="0.7"/>
+    <circle cx="164" cy="39" r="2.5" fill="#000" opacity="0.45"/>
+    <circle cx="172" cy="39" r="2.5" fill="#000" opacity="0.2"/>
+    <text x="186" y="43" font-size="11" fill="#000" opacity="0.7">disabled while in flight</text>
+  </g>
+
+  <!-- 4. Spinner (last resort) -->
+  <g transform="translate(40,264)">
+    <rect x="0" y="0" width="440" height="68" fill="#f11300" fill-opacity="0.1" stroke="#000" stroke-dasharray="4 3"/>
+    <text x="14" y="20" font-size="12" fill="#000">4. Spinner — last resort</text>
+    <!-- spinner ring -->
+    <g transform="translate(40,46)">
+      <circle cx="0" cy="0" r="12" fill="none" stroke="#000" stroke-width="3" stroke-opacity="0.2"/>
+      <path d="M 0 -12 A 12 12 0 0 1 12 0" fill="none" stroke="#000" stroke-width="3" stroke-linecap="round"/>
+    </g>
+    <text x="64" y="42" font-size="11" fill="#000">no length, no shape, no message</text>
+    <text x="64" y="58" font-size="10" fill="#000" opacity="0.6">use only for very short or genuinely indeterminate waits</text>
+  </g>
+
+  <!-- Wordmark -->
+  <text x="510" y="354" text-anchor="end" font-size="9" fill="#000" opacity="0.25">SPEEDPATTERNS.COM</text>
+</svg>

--- a/src/patterns/progress_indication.md
+++ b/src/patterns/progress_indication.md
@@ -5,6 +5,7 @@ tags: pattern
 thumbnail: /assets/progress_indication_thumbnail.svg
 og_image: /assets/speed_patterns_og_image.jpg
 order: 12
+ai_assisted: true
 date: 2024-04-23
 authors:
     - name: Alexander Chernyshev

--- a/src/patterns/progress_indication.md
+++ b/src/patterns/progress_indication.md
@@ -1,0 +1,77 @@
+---
+layout: article.njk
+title: Progress Indication
+tags: pattern
+thumbnail: /assets/progress_indication_thumbnail.svg
+og_image: /assets/speed_patterns_og_image.jpg
+order: 12
+---
+
+When work takes long enough that the user notices, "nothing visible is happening" stops being acceptable. Some form of progress indication is required — but the choice of which form has a much bigger impact on the experience than teams often realize.
+
+<!-- excerpt -->
+
+## The Problem
+
+A page or interaction that takes more than about a second to complete needs to communicate its progress to the user. Without that communication:
+
+- The user assumes the page is broken and reloads, navigates away, or rage-clicks
+- Repeated submissions and duplicate actions become common
+- Trust in the site erodes even when the operation eventually succeeds
+
+But not all forms of progress indication are equal. The default reach for a generic spinner — circular, infinite, decoupled from the actual work — communicates almost nothing useful. Choosing the right form is itself a design decision.
+
+## Solution
+
+Pick the form of progress indication that matches what you actually know about the operation. There's a small ladder of options, ordered from most informative to least:
+
+<figure>
+<img src="/assets/progress_indication_thumbnail.svg" width="480" alt="Four stacked options: a determinate progress bar labeled 'real progress (preferred)', a skeleton layout labeled 'structural placeholder', a labeled action button reading 'Submitting…' for action acknowledgment, and a circular spinner with a dashed red border labeled 'last resort'"/>
+<figcaption>Four ways to indicate progress, ordered from most to least informative</figcaption>
+</figure>
+
+### 1. Real progress, when you have it
+
+For uploads, downloads, multi-step forms, batch operations and any wait with measurable steps, show a determinate progress bar with percentage and, where possible, a description of the current step ("Uploading 3 of 8…"). This is the only place a literal progress indicator earns its space on the screen — it tells the user how long they're waiting and what's happening.
+
+### 2. Structural placeholders
+
+For loading content into a region of the page, use a [Skeletal Design](/patterns/skeletal_designs/) that mirrors the final layout. This communicates _what_ the content will be, _where_ it will appear, and _how_ the page is structured — none of which a spinner can do. Skeletal placeholders are the right answer for feeds, lists, dashboards and article bodies.
+
+### 3. Action acknowledgments
+
+For discrete user actions (form submits, button clicks, link follows), [acknowledge the action](/patterns/acknowledge_actions/) directly: disable the trigger, change its label to describe what's happening, and confirm completion when it lands. This is more informative than any generic indicator because it's tied to the specific control the user touched.
+
+### 4. Motion-based bridging
+
+For unavoidable view transitions, [mask slowness with animation](/patterns/masking_slowness_with_animation/). A short, purposeful transition that takes the user from the old state toward the new one absorbs a meaningful amount of the wait and communicates direction.
+
+### 5. Generic spinners — last resort
+
+Plain circular or linear indeterminate spinners belong at the bottom of the ladder. They're acceptable in narrow cases — very short waits inside a single control, genuinely indeterminate background work — but should never be the default choice. See [Don't Use Spinners](/patterns/dont_use_spinners/) for the full argument.
+
+## Why This Matters
+
+The form of progress indication shapes how the wait _feels_, even when its length doesn't change. A skeletal placeholder that telegraphs the page structure feels faster than a spinner that telegraphs nothing — even when both end at the same moment. A "Submitting…" button feels reliable; a full-page overlay spinner feels like the site has frozen.
+
+Treating the loading experience as a design problem with multiple specific solutions, rather than a hole to plug with a single stock animation, is what separates speed-aware products from the rest.
+
+## Guidelines
+
+- **Match the indicator to what you know.** Determinate progress requires a known length; if you don't have one, don't fake it
+- **Indicate progress in place.** Show the indicator on or next to the thing the user is waiting for, not in a distant overlay
+- **Don't stack indicators.** A spinner _on top of_ a skeletal placeholder _on top of_ a progress bar communicates panic, not progress
+- **Hide the indicator the moment the wait ends.** A spinner that lingers after content loads makes the page feel slower than it is
+- **Use indicators sparingly.** The best progress indicator is no progress indicator — make the operation fast enough that one isn't needed
+
+## Related Patterns
+
+- [Skeletal Designs](/patterns/skeletal_designs/) — structural placeholders that double as progress indication
+- [Acknowledge Actions](/patterns/acknowledge_actions/) — feedback for discrete user actions
+- [Masking Slowness With Animation](/patterns/masking_slowness_with_animation/) — motion as a progress signal
+- [Don't Use Spinners](/patterns/dont_use_spinners/) — why the generic spinner is a poor default
+
+## Resources
+
+- [Mobile Design Details: Avoid The Spinner](https://www.lukew.com/ff/entry.asp?1797) by [Luke Wroblewski](https://lukew.com/)
+- [Response Times: The 3 Important Limits](https://www.nngroup.com/articles/response-times-3-important-limits/) by Jakob Nielsen — the 0.1s / 1s / 10s thresholds that determine when progress indication is needed at all

--- a/src/patterns/progress_indication.md
+++ b/src/patterns/progress_indication.md
@@ -5,6 +5,10 @@ tags: pattern
 thumbnail: /assets/progress_indication_thumbnail.svg
 og_image: /assets/speed_patterns_og_image.jpg
 order: 12
+date: 2024-04-23
+authors:
+    - name: Alexander Chernyshev
+      url: https://alexchernyshev.com/
 ---
 
 When work takes long enough that the user notices, "nothing visible is happening" stops being acceptable. Some form of progress indication is required — but the choice of which form has a much bigger impact on the experience than teams often realize.


### PR DESCRIPTION
## Summary
- Adds an umbrella pattern article describing the ladder of progress-indication options: real determinate progress, structural placeholders, action acknowledgments, motion-based bridging, and (last) generic spinners.
- Cross-links to the existing Skeletal Designs / Acknowledge Actions / Masking Slowness With Animation / Don't Use Spinners patterns.
- Includes a simple SVG thumbnail and reuses the site-wide OG image.

Closes #24

## Test plan
- [ ] Run `npm run start` and verify the article renders at `/patterns/progress_indication/`
- [ ] Confirm the new pattern appears in the homepage list with thumbnail
- [ ] Confirm the new pattern shows up in the side nav

🤖 Generated with [Claude Code](https://claude.com/claude-code)
