### PR TITLE
Add Optimistic Rendering pattern

### DIFF
--- a/src/assets/optimistic_rendering_thumbnail.svg
+++ b/src/assets/optimistic_rendering_thumbnail.svg
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 520 320" width="520" height="320" font-family="Arial, sans-serif">
+  <title>Optimistic Rendering</title>
+  <desc>Two flows compared. Left, labeled "pessimistic": a click step, a spinner/wait step, then a filled-heart success state, connected by blue arrows in a vertical sequence. Right, labeled "optimistic": a click step jumping straight to the filled-heart success state, with a small label "reconciles in background".</desc>
+
+  <rect width="520" height="320" fill="#fff"/>
+
+  <!-- Pessimistic flow (left) -->
+  <g>
+    <rect x="20" y="40" width="220" height="240" fill="#f11300" fill-opacity="0.08" stroke="#000"/>
+    <text x="130" y="30" text-anchor="middle" font-size="13" fill="#000">pessimistic</text>
+
+    <!-- step 1: click -->
+    <rect x="60" y="56" width="140" height="40" fill="#fff" stroke="#000"/>
+    <text x="130" y="73" text-anchor="middle" font-size="12" fill="#000">click ♥</text>
+    <text x="130" y="89" text-anchor="middle" font-size="10" fill="#000" opacity="0.6">user input</text>
+
+    <!-- arrow -->
+    <line x1="130" y1="100" x2="130" y2="124" stroke="#0085f1" stroke-width="2"/>
+    <polygon points="126,120 134,120 130,128" fill="#0085f1"/>
+
+    <!-- step 2: wait/spinner -->
+    <rect x="60" y="132" width="140" height="56" fill="#fff" stroke="#000"/>
+    <g transform="translate(96,160)">
+      <circle cx="0" cy="0" r="9" fill="none" stroke="#000" stroke-width="2.5" stroke-opacity="0.2"/>
+      <path d="M 0 -9 A 9 9 0 0 1 9 0" fill="none" stroke="#000" stroke-width="2.5" stroke-linecap="round"/>
+    </g>
+    <text x="118" y="156" font-size="11" fill="#000">waiting…</text>
+    <text x="118" y="170" font-size="10" fill="#000" opacity="0.6">round-trip</text>
+
+    <!-- arrow -->
+    <line x1="130" y1="192" x2="130" y2="216" stroke="#0085f1" stroke-width="2"/>
+    <polygon points="126,212 134,212 130,220" fill="#0085f1"/>
+
+    <!-- step 3: filled state -->
+    <rect x="60" y="224" width="140" height="40" fill="#fff" stroke="#000"/>
+    <text x="130" y="241" text-anchor="middle" font-size="12" fill="#000">♥ filled</text>
+    <text x="130" y="257" text-anchor="middle" font-size="10" fill="#000" opacity="0.6">success state</text>
+  </g>
+
+  <!-- Optimistic flow (right) -->
+  <g>
+    <rect x="280" y="40" width="220" height="240" fill="#00f13e" fill-opacity="0.12" stroke="#000"/>
+    <text x="390" y="30" text-anchor="middle" font-size="13" fill="#000">optimistic</text>
+
+    <!-- step 1: click -->
+    <rect x="320" y="56" width="140" height="40" fill="#fff" stroke="#000"/>
+    <text x="390" y="73" text-anchor="middle" font-size="12" fill="#000">click ♥</text>
+    <text x="390" y="89" text-anchor="middle" font-size="10" fill="#000" opacity="0.6">user input</text>
+
+    <!-- arrow direct to success -->
+    <line x1="390" y1="100" x2="390" y2="148" stroke="#0085f1" stroke-width="2"/>
+    <polygon points="386,144 394,144 390,152" fill="#0085f1"/>
+
+    <!-- step 2: success state immediately -->
+    <rect x="320" y="156" width="140" height="48" fill="#fff" stroke="#000"/>
+    <text x="390" y="178" text-anchor="middle" font-size="13" fill="#000">♥ filled</text>
+    <text x="390" y="194" text-anchor="middle" font-size="10" fill="#000" opacity="0.6">shown immediately</text>
+
+    <!-- background reconcile note -->
+    <rect x="320" y="220" width="140" height="44" fill="#fff" stroke="#000" stroke-dasharray="3 2"/>
+    <text x="390" y="240" text-anchor="middle" font-size="10" fill="#000" opacity="0.7">reconciles in</text>
+    <text x="390" y="254" text-anchor="middle" font-size="10" fill="#000" opacity="0.7">background</text>
+  </g>
+
+  <!-- Wordmark -->
+  <text x="510" y="312" text-anchor="end" font-size="9" fill="#000" opacity="0.25">SPEEDPATTERNS.COM</text>
+</svg>

--- a/src/patterns/optimistic_rendering.md
+++ b/src/patterns/optimistic_rendering.md
@@ -5,6 +5,7 @@ tags: pattern
 thumbnail: /assets/optimistic_rendering_thumbnail.svg
 og_image: /assets/speed_patterns_og_image.jpg
 order: 13
+ai_assisted: true
 date: 2024-04-23
 authors:
     - name: Alexander Chernyshev

--- a/src/patterns/optimistic_rendering.md
+++ b/src/patterns/optimistic_rendering.md
@@ -1,0 +1,88 @@
+---
+layout: article.njk
+title: Optimistic Rendering
+tags: pattern
+thumbnail: /assets/optimistic_rendering_thumbnail.svg
+og_image: /assets/speed_patterns_og_image.jpg
+order: 13
+---
+
+When a user performs an action whose result is highly likely to succeed, you don't have to wait for the server to confirm before showing the new state. Render the success state in the UI as soon as the input lands — and reconcile silently in the background.
+
+<!-- excerpt -->
+
+## The Problem
+
+Many user actions involve a server round-trip: liking a post, adding an item to a cart, posting a comment, reordering a list, marking a task done. The natural implementation waits for the server to respond before updating the UI:
+
+1. User clicks
+2. UI shows a spinner or disabled state
+3. Network request goes out
+4. Server processes and replies
+5. UI finally updates to reflect the new state
+
+The user sits through every step. Even when the request succeeds in 200ms, that's 200ms of "waiting for the heart to fill in" or "waiting for the item to appear in the cart" — a delay between cause and effect that feels much longer than the same number of milliseconds spent doing nothing.
+
+## Solution
+
+Render the new state immediately, as if the server had already responded successfully. Send the request in parallel and reconcile when the real response arrives. If it fails, roll back and surface a clear failure message.
+
+<figure>
+<img src="/assets/optimistic_rendering_thumbnail.svg" width="460" alt="Two flows side by side. Left, labeled 'pessimistic': click → spinner → wait → success state. Right, labeled 'optimistic': click → success state immediately, with a small note 'reconciles in background'."/>
+<figcaption>Render the success state now, reconcile later</figcaption>
+</figure>
+
+The user perceives the action as instantaneous because, from their point of view, it _is_ instantaneous. The work of synchronizing with the server happens out of sight.
+
+### Where this works well
+
+- **Reactions and toggles** — likes, favorites, follows, bookmarks, mute/unmute
+- **List operations** — adding to a cart, dragging to reorder, marking a to-do done, archiving an email
+- **Inline content creation** — posting a comment, sending a chat message, leaving a review
+- **Multi-step flows** — moving to the next step in a wizard while the previous step's data is still being persisted
+
+In every case, the operation has a high success rate, the new state is well-defined locally, and the user has more work they want to do without waiting.
+
+### Where this doesn't work
+
+- **Operations that gate other actions** — payment authorization, account creation, anything the next screen depends on
+- **Operations the user expects to verify** — long-form publishing, financial transfers, file uploads with size or format constraints
+- **Operations with a real failure rate** — if rollback would happen often enough that users learn to distrust the UI, optimism is the wrong call
+
+## Why This Works
+
+Latency that the user can't see has a much smaller effect on perceived performance than latency they can see. By rendering the result before the round-trip completes, the round-trip stops being part of the user's experience of the action. The wait still exists technically, but it stops being a wait.
+
+Optimism only works because most operations succeed. When the failure rate is low enough — well under a percent for many UI actions — paying the rare cost of rolling back is a much better trade than paying the round-trip cost on every successful action.
+
+## Guidelines
+
+- **Make the rollback visible and clear.** If the optimistic state turns out to be wrong, the user must understand what happened. A toast like "We couldn't save your comment — try again" plus restoring the prior state is the minimum
+- **Keep the optimistic state local until confirmed.** Don't propagate the unconfirmed state to other clients, search indexes, or analytics until the server confirms
+- **Reconcile on the real response.** When the server replies, replace the optimistic value with the canonical one — server-assigned IDs, timestamps, ordering, and any normalization the server applies should win
+- **Handle conflicts.** If another client changed the same data, the optimistic update may need to be rebased or surfaced as a conflict, not silently discarded
+- **Don't be optimistic about everything.** Reserve optimism for the operations where it actually pays off; mixing optimistic and pessimistic UI in the same view is fine
+- **Pair with [Acknowledge Actions](/patterns/acknowledge_actions/).** Even an optimistic action benefits from a small confirmation — a subtle inline indicator that briefly says "saved" gives the user a hook to notice if it ever fails
+
+## Related Patterns
+
+- [Acknowledge Actions](/patterns/acknowledge_actions/) — for actions where you can't be optimistic but still need to feel responsive
+- [Masking Slowness With Animation](/patterns/masking_slowness_with_animation/) — when the optimistic state needs a brief animated transition into place
+- [Don't Use Spinners](/patterns/dont_use_spinners/) — optimism is one of the best ways to avoid needing a spinner at all
+
+## Technical Implementation
+
+Most modern UI frameworks have first-class support for this pattern:
+
+- **React** ships [`useOptimistic`](https://react.dev/reference/react/useOptimistic), which manages the optimistic state and rollback automatically
+- **TanStack Query** and **SWR** both support [optimistic updates](https://tanstack.com/query/latest/docs/framework/react/guides/optimistic-updates) on mutations, with built-in invalidation and rollback on error
+- **Redux Toolkit Query** offers [optimistic updates via `onQueryStarted`](https://redux-toolkit.js.org/rtk-query/usage/manual-cache-updates#optimistic-updates), undoing the patch on failure
+- **Apollo Client** supports [`optimisticResponse`](https://www.apollographql.com/docs/react/performance/optimistic-ui/) on mutations
+
+The shape of the implementation is always the same: apply a local state change immediately; fire the request; on success, replace the local state with the server's; on failure, undo the local state and surface an error. The framework abstractions just package those steps.
+
+## Resources
+
+- [Being Optimistic in UI](https://dev.to/tiagodcosta/being-optimistic-in-ui-511k) by Tiago da Costa
+- [Optimistic UI with React](https://react.dev/reference/react/useOptimistic) — official React documentation
+- [Optimistic Updates in TanStack Query](https://tanstack.com/query/latest/docs/framework/react/guides/optimistic-updates)

--- a/src/patterns/optimistic_rendering.md
+++ b/src/patterns/optimistic_rendering.md
@@ -5,6 +5,10 @@ tags: pattern
 thumbnail: /assets/optimistic_rendering_thumbnail.svg
 og_image: /assets/speed_patterns_og_image.jpg
 order: 13
+date: 2024-04-23
+authors:
+    - name: Alexander Chernyshev
+      url: https://alexchernyshev.com/
 ---
 
 When a user performs an action whose result is highly likely to succeed, you don't have to wait for the server to confirm before showing the new state. Render the success state in the UI as soon as the input lands — and reconcile silently in the background.


### PR DESCRIPTION
## Summary
- Adds a new pattern article on rendering the success state of likely-to-succeed operations immediately, while reconciling with the server in the background; covers when this is appropriate, when it isn't, rollback handling, and framework support.
- Includes a simple SVG thumbnail and reuses the site-wide OG image.

Closes #25

## Test plan
- [ ] Run `npm run start` and verify the article renders at `/patterns/optimistic_rendering/`
- [ ] Confirm the new pattern appears in the homepage list with thumbnail
- [ ] Confirm the new pattern shows up in the side nav

🤖 Generated with [Claude Code](https://claude.com/claude-code)
