### PR TITLE
Add Optimistic Actions pattern

### DIFF
--- a/src/assets/optimistic_actions_thumbnail.svg
+++ b/src/assets/optimistic_actions_thumbnail.svg
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 520 320" width="520" height="320" font-family="Arial, sans-serif">
+  <title>Optimistic Actions</title>
+  <desc>Two coupon lists side by side. The left list, labeled "without optimism", shows three coupons each in a "Clipping…" pending state with spinners. The right list, labeled "with optimism", shows the same three coupons each immediately marked "Clipped ✓".</desc>
+
+  <rect width="520" height="320" fill="#fff"/>
+
+  <text x="260" y="26" text-anchor="middle" font-size="14" fill="#000">Repetitive actions feel slow when each one waits</text>
+
+  <!-- Without optimism (left) -->
+  <g>
+    <rect x="20" y="48" width="220" height="240" fill="#f11300" fill-opacity="0.08" stroke="#000"/>
+    <text x="130" y="68" text-anchor="middle" font-size="13" fill="#000">without optimism</text>
+
+    <!-- coupon row template -->
+    <g transform="translate(36,84)">
+      <rect x="0" y="0" width="188" height="40" fill="#fff" stroke="#000"/>
+      <text x="10" y="18" font-size="11" fill="#000">10% off — pasta</text>
+      <text x="10" y="32" font-size="9" fill="#000" opacity="0.55">expires soon</text>
+      <rect x="120" y="10" width="60" height="20" fill="#fff" stroke="#000" stroke-dasharray="3 2"/>
+      <g transform="translate(132,20)">
+        <circle cx="0" cy="0" r="5" fill="none" stroke="#000" stroke-width="2" stroke-opacity="0.2"/>
+        <path d="M 0 -5 A 5 5 0 0 1 5 0" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round"/>
+      </g>
+      <text x="158" y="24" text-anchor="middle" font-size="9" fill="#000">…</text>
+    </g>
+    <g transform="translate(36,134)">
+      <rect x="0" y="0" width="188" height="40" fill="#fff" stroke="#000"/>
+      <text x="10" y="18" font-size="11" fill="#000">$2 off — bread</text>
+      <text x="10" y="32" font-size="9" fill="#000" opacity="0.55">members only</text>
+      <rect x="120" y="10" width="60" height="20" fill="#fff" stroke="#000" stroke-dasharray="3 2"/>
+      <g transform="translate(132,20)">
+        <circle cx="0" cy="0" r="5" fill="none" stroke="#000" stroke-width="2" stroke-opacity="0.2"/>
+        <path d="M 0 -5 A 5 5 0 0 1 5 0" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round"/>
+      </g>
+      <text x="158" y="24" text-anchor="middle" font-size="9" fill="#000">…</text>
+    </g>
+    <g transform="translate(36,184)">
+      <rect x="0" y="0" width="188" height="40" fill="#fff" stroke="#000"/>
+      <text x="10" y="18" font-size="11" fill="#000">15% off — produce</text>
+      <text x="10" y="32" font-size="9" fill="#000" opacity="0.55">ends Friday</text>
+      <rect x="120" y="10" width="60" height="20" fill="#fff" stroke="#000" stroke-dasharray="3 2"/>
+      <g transform="translate(132,20)">
+        <circle cx="0" cy="0" r="5" fill="none" stroke="#000" stroke-width="2" stroke-opacity="0.2"/>
+        <path d="M 0 -5 A 5 5 0 0 1 5 0" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round"/>
+      </g>
+      <text x="158" y="24" text-anchor="middle" font-size="9" fill="#000">…</text>
+    </g>
+
+    <text x="130" y="252" text-anchor="middle" font-size="11" fill="#000" opacity="0.7">each click waits for the server</text>
+    <text x="130" y="270" text-anchor="middle" font-size="11" fill="#000" opacity="0.7">cumulative delay across many clicks</text>
+  </g>
+
+  <!-- With optimism (right) -->
+  <g>
+    <rect x="280" y="48" width="220" height="240" fill="#00f13e" fill-opacity="0.12" stroke="#000"/>
+    <text x="390" y="68" text-anchor="middle" font-size="13" fill="#000">with optimism</text>
+
+    <g transform="translate(296,84)">
+      <rect x="0" y="0" width="188" height="40" fill="#fff" stroke="#000"/>
+      <text x="10" y="18" font-size="11" fill="#000">10% off — pasta</text>
+      <text x="10" y="32" font-size="9" fill="#000" opacity="0.55">expires soon</text>
+      <rect x="120" y="10" width="60" height="20" fill="#00f13e" fill-opacity="0.25" stroke="#000"/>
+      <text x="150" y="24" text-anchor="middle" font-size="10" fill="#000">Clipped ✓</text>
+    </g>
+    <g transform="translate(296,134)">
+      <rect x="0" y="0" width="188" height="40" fill="#fff" stroke="#000"/>
+      <text x="10" y="18" font-size="11" fill="#000">$2 off — bread</text>
+      <text x="10" y="32" font-size="9" fill="#000" opacity="0.55">members only</text>
+      <rect x="120" y="10" width="60" height="20" fill="#00f13e" fill-opacity="0.25" stroke="#000"/>
+      <text x="150" y="24" text-anchor="middle" font-size="10" fill="#000">Clipped ✓</text>
+    </g>
+    <g transform="translate(296,184)">
+      <rect x="0" y="0" width="188" height="40" fill="#fff" stroke="#000"/>
+      <text x="10" y="18" font-size="11" fill="#000">15% off — produce</text>
+      <text x="10" y="32" font-size="9" fill="#000" opacity="0.55">ends Friday</text>
+      <rect x="120" y="10" width="60" height="20" fill="#00f13e" fill-opacity="0.25" stroke="#000"/>
+      <text x="150" y="24" text-anchor="middle" font-size="10" fill="#000">Clipped ✓</text>
+    </g>
+
+    <text x="390" y="252" text-anchor="middle" font-size="11" fill="#000" opacity="0.7">success state lands instantly</text>
+    <text x="390" y="270" text-anchor="middle" font-size="11" fill="#000" opacity="0.7">requests reconcile in the background</text>
+  </g>
+
+  <!-- Wordmark -->
+  <text x="510" y="312" text-anchor="end" font-size="9" fill="#000" opacity="0.25">SPEEDPATTERNS.COM</text>
+</svg>

--- a/src/patterns/optimistic_actions.md
+++ b/src/patterns/optimistic_actions.md
@@ -5,6 +5,12 @@ tags: pattern
 thumbnail: /assets/optimistic_actions_thumbnail.svg
 og_image: /assets/speed_patterns_og_image.jpg
 order: 14
+date: 2020-01-06
+authors:
+    - name: Joseph Gannon
+      url: https://www.linkedin.com/in/environmentalux/
+    - name: Sergey Chernyshev
+      url: https://www.sergeychernyshev.com/
 ---
 
 Some user actions don't need to wait for the server to feel complete. Clipping a coupon, marking a task done, voting on a poll, adding to a wishlist — for actions like these, the user has formed an intent and moved on before the request even leaves the device. Designing the action flow around that fact is what turns a usable feature into one that feels instantaneous.

--- a/src/patterns/optimistic_actions.md
+++ b/src/patterns/optimistic_actions.md
@@ -1,0 +1,68 @@
+---
+layout: article.njk
+title: Optimistic Actions
+tags: pattern
+thumbnail: /assets/optimistic_actions_thumbnail.svg
+og_image: /assets/speed_patterns_og_image.jpg
+order: 14
+---
+
+Some user actions don't need to wait for the server to feel complete. Clipping a coupon, marking a task done, voting on a poll, adding to a wishlist — for actions like these, the user has formed an intent and moved on before the request even leaves the device. Designing the action flow around that fact is what turns a usable feature into one that feels instantaneous.
+
+<!-- excerpt -->
+
+## The Problem
+
+Even fast servers add latency that the user can feel. A 200ms round-trip is invisible on a benchmark and very visible on a coupon-clipping list, where the user is trying to clip ten coupons in five seconds. Each pause between "click" and "clipped" stacks up:
+
+- The user clicks ten coupon buttons
+- Each one disables, shows a small spinner, then ticks to "clipped"
+- The total task takes the user three or four seconds longer than it had to
+- Worse, the cumulative friction makes the whole feature feel slow even if any single action is acceptable
+
+The same shape repeats across every product: bulk-archive in an email client, add-to-cart on a shop, like-button mash on a social feed. The cost isn't a single slow action — it's the accumulated waiting across many fast ones.
+
+## Solution
+
+Decide, at design time, that certain user actions should appear to complete instantaneously regardless of the underlying network. The action's _visible_ outcome lands on the next paint after the user's input. The actual work — the request, the response, the persistence — happens behind that outcome, not in front of it.
+
+This is the umbrella pattern; the specific rendering technique that delivers it is [Optimistic Rendering](/patterns/optimistic_rendering/).
+
+### Which actions are candidates?
+
+An action is a good candidate for this treatment when **all** of the following are true:
+
+- **High success rate.** The action almost always succeeds. If failure is common, optimism trains the user to distrust the UI
+- **Local, well-defined outcome.** The new state can be expressed entirely in the client without waiting for server-assigned data
+- **Doesn't gate the next step.** The user shouldn't depend on the result to make their next decision (payments and account creation are obvious counter-examples)
+- **Reversible.** If the optimistic outcome turns out to be wrong, rolling back is straightforward and won't have already cascaded into other UI
+- **Repetitive or fast-paced.** The benefit grows with how often the user performs the action — clipping coupons, swiping cards, reordering a list
+
+A coupon-clip ticks every box. A "complete checkout" button ticks none of them.
+
+## Why This Matters
+
+Google's [RAIL model](https://web.dev/articles/rail) calls out the **100ms** mark as the threshold below which an action feels instantaneous. The full **0–1s** window is workable with acknowledgment, and beyond that the user disengages. Optimistic actions move the experience squarely under 100ms — not by making the network faster, but by removing the network from the user's experience of the action.
+
+For repetitive workflows, this isn't just a perceived-performance win — it's a throughput win. Users complete the task faster, accumulate less waiting time, and leave the feature with the impression that it works.
+
+## Guidelines
+
+- **Choose deliberately.** Don't make every action optimistic by reflex. The decision should follow from the product/design conversation, not from a framework default
+- **Plan the failure path.** Define exactly what happens when an optimistic action fails — rollback, error message, opportunity to retry. Make it specific to the action; a generic toast isn't enough for actions that matter
+- **Don't be optimistic about money or identity.** Anything financial, security-critical, or legally consequential should be visibly pessimistic — the user expects, and is reassured by, an explicit confirmation
+- **Combine with [Acknowledge Actions](/patterns/acknowledge_actions/) when appropriate.** Even an optimistic action can include a tiny inline confirmation ("saved", a quick check icon) that gives the user a hook to notice if anything went wrong
+- **Validate the assumption with users.** "Probability of success is high" is an empirical claim, not an aesthetic one. Watch real-user metrics for the action's failure rate. If it climbs, the pattern stops paying off
+- **Be honest about what's still happening.** Some users — or some operations — benefit from the small delay of an explicit confirmation. User research on the specific action will tell you whether speed or certainty is more valuable
+
+## Related Patterns
+
+- [Optimistic Rendering](/patterns/optimistic_rendering/) — the UI technique used to deliver optimistic actions; covers state management, reconciliation, and rollback
+- [Acknowledge Actions](/patterns/acknowledge_actions/) — for actions that can't be optimistic but still need to feel responsive
+- [Don't Use Spinners](/patterns/dont_use_spinners/) — optimism is one of the strongest tools for avoiding spinners on user actions
+
+## Resources
+
+- [Measure Performance with the RAIL Model](https://web.dev/articles/rail) on web.dev
+- [Being Optimistic in UI](https://dev.to/tiagodcosta/being-optimistic-in-ui-511k) by Tiago da Costa
+- [Response Times: The 3 Important Limits](https://www.nngroup.com/articles/response-times-3-important-limits/) by Jakob Nielsen

--- a/src/patterns/optimistic_actions.md
+++ b/src/patterns/optimistic_actions.md
@@ -5,6 +5,7 @@ tags: pattern
 thumbnail: /assets/optimistic_actions_thumbnail.svg
 og_image: /assets/speed_patterns_og_image.jpg
 order: 14
+ai_assisted: true
 date: 2020-01-06
 authors:
     - name: Joseph Gannon


### PR DESCRIPTION
## Summary
- Adds a new pattern article framing optimistic actions as a deliberate product/design decision: which user actions qualify (high success rate, local outcome, reversible, repetitive), how to handle failure, and where the pattern doesn't apply (payments, identity, anything gating the next step).
- Cross-links to the sibling Optimistic Rendering pattern (the rendering technique) and to Acknowledge Actions / Don't Use Spinners.
- Includes a simple SVG thumbnail illustrating the difference on a coupon-clipping example, and reuses the site-wide OG image.

Closes #12

## Test plan
- [ ] Run `npm run start` and verify the article renders at `/patterns/optimistic_actions/`
- [ ] Confirm the new pattern appears in the homepage list with thumbnail
- [ ] Confirm the new pattern shows up in the side nav

🤖 Generated with [Claude Code](https://claude.com/claude-code)
